### PR TITLE
sign-in-thrid-party page ui added; button style added

### DIFF
--- a/src/popup/Router.tsx
+++ b/src/popup/Router.tsx
@@ -20,7 +20,7 @@ import { POPUP_WIDTH } from "popup/constants";
 
 import Account from "popup/views/Account";
 import CreatePassword from "popup/views/CreatePassword";
-import GrantAccess from "popup/views/GrantAccess";
+import { GrantAccess } from "popup/views/GrantAccess";
 import MnemonicPhrase from "popup/views/MnemonicPhrase";
 import MnemonicPhraseConfirmed from "popup/views/MnemonicPhrase/Confirmed";
 import RecoverAccount from "popup/views/RecoverAccount";

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -5,7 +5,7 @@ import { ErrorMessage, Field } from "formik";
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
 
 /* Button */
-export const BasicButtonEl = styled.button`
+export const BasicButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
@@ -98,7 +98,7 @@ export const ApiErrorMessage = ({ error }: ErrorMessageProps) => (
   <>{error ? <FormErrorEl>{error}</FormErrorEl> : null}</>
 );
 
-export const FormButton = styled(BasicButtonEl)`
+export const FormButton = styled(BasicButton)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 1.5rem;
   color: ${COLOR_PALETTE.white};

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import { ErrorMessage, Field } from "formik";
-import { COLOR_PALETTE } from "popup/styles";
 
-interface ErrorMessageProps {
-  error: string;
-}
+import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
 
-export const Button = styled.button`
+/* Button */
+export const BasicButtonEl = styled.button`
   background: none;
   border: none;
   cursor: pointer;
@@ -21,6 +19,38 @@ export const Button = styled.button`
     cursor: not-allowed;
   }
 `;
+
+interface ButtonProps {
+  size?: string;
+  onClick(): any;
+  children: React.ReactNode;
+}
+
+export const ButtonEl = styled.button<ButtonProps>`
+  width: ${(props) => (props.size === "small" ? "8.75rem" : "12.375rem")};
+  display: ${(props) => (props.size === "small" ? "inline-block" : "block")};
+  margin: 0 auto;
+  font-size: 0.8rem;
+  font-weight: ${FONT_WEIGHT.bold};
+  padding: 1.45rem;
+  border-radius: 20px;
+  background: ${COLOR_PALETTE.primaryGradient};
+  color: ${COLOR_PALETTE.white};
+  border: none;
+  cursor: pointer;
+  -webkit-appearance: none;
+`;
+
+export const Button = ({ size, children, onClick, ...props }: ButtonProps) => (
+  <ButtonEl size={size} onClick={onClick} {...props}>
+    {children}
+  </ButtonEl>
+);
+
+/* Form */
+interface ErrorMessageProps {
+  error: string;
+}
 
 const FormErrorEl = styled.div`
   color: ${COLOR_PALETTE.error};
@@ -68,10 +98,10 @@ export const ApiErrorMessage = ({ error }: ErrorMessageProps) => (
   <>{error ? <FormErrorEl>{error}</FormErrorEl> : null}</>
 );
 
-export const FormButton = styled(Button)`
+export const FormButton = styled(BasicButtonEl)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 1.5rem;
-  color: #fff;
+  color: ${COLOR_PALETTE.white};
   display: block;
   font-size: 1.1rem;
   font-weight: 600;

--- a/src/popup/components/Layout/Fullscreen/Onboarding.tsx
+++ b/src/popup/components/Layout/Fullscreen/Onboarding.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
-import { Button } from "popup/basics";
+import { BasicButtonEl } from "popup/basics";
 import FullscreenStyle from "./basics/FullscreenStyle";
 
 const HeaderEl = styled.h1`
@@ -40,7 +40,7 @@ const EmojiSpan = styled.span`
   font-size: 3.625rem;
 `;
 
-const BackButton = styled(Button)`
+const BackButton = styled(BasicButtonEl)`
   margin: 1rem 0 0 2.75rem;
 `;
 

--- a/src/popup/components/Layout/Fullscreen/Onboarding.tsx
+++ b/src/popup/components/Layout/Fullscreen/Onboarding.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
-import { BasicButtonEl } from "popup/basics";
+import { BasicButton } from "popup/basics";
 import FullscreenStyle from "./basics/FullscreenStyle";
 
 const HeaderEl = styled.h1`
@@ -40,7 +40,7 @@ const EmojiSpan = styled.span`
   font-size: 3.625rem;
 `;
 
-const BackButton = styled(BasicButtonEl)`
+const BackButton = styled(BasicButton)`
   margin: 1rem 0 0 2.75rem;
 `;
 

--- a/src/popup/components/Layout/Header/index.tsx
+++ b/src/popup/components/Layout/Header/index.tsx
@@ -8,7 +8,8 @@ const HeaderEl = styled.header`
   font-family: "Muli";
   display: flex;
   justify-content: space-between;
-  padding: 2.375rem 3.375rem;
+  align-items: center;
+  padding: 2.25rem 2rem;
   text-align: left;
 `;
 
@@ -32,8 +33,8 @@ type HeaderProps = {
   className?: string;
 };
 
-export const Header = ({ className }: HeaderProps) => (
-  <HeaderEl className={className}>
+export const Header = ({ className, ...props }: HeaderProps) => (
+  <HeaderEl className={className} {...props}>
     <HeaderH1>Lyra</HeaderH1>
     <NetworkEl>Test net</NetworkEl>
   </HeaderEl>

--- a/src/popup/components/Menu/index.tsx
+++ b/src/popup/components/Menu/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { APPLICATION_STATE } from "statics";
 
-import { BasicButtonEl } from "popup/basics";
+import { BasicButton } from "popup/basics";
 import { Z_INDEXES, COLOR_PALETTE } from "popup/styles";
 import { POPUP_WIDTH } from "popup/constants";
 
@@ -33,7 +33,7 @@ const MenuHeader = styled(Header)`
 const MenuEl = styled.div`
   padding: 0.675rem 3.375rem;
 `;
-const MenuOpenButton = styled(BasicButtonEl)`
+const MenuOpenButton = styled(BasicButton)`
   display: inline-block;
   background: url(${MenuIcon});
   background-size: cover;

--- a/src/popup/components/Menu/index.tsx
+++ b/src/popup/components/Menu/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { APPLICATION_STATE } from "statics";
 
-import { Button } from "popup/basics";
+import { BasicButtonEl } from "popup/basics";
 import { Z_INDEXES, COLOR_PALETTE } from "popup/styles";
 import { POPUP_WIDTH } from "popup/constants";
 
@@ -33,7 +33,7 @@ const MenuHeader = styled(Header)`
 const MenuEl = styled.div`
   padding: 0.675rem 3.375rem;
 `;
-const MenuOpenButton = styled(Button)`
+const MenuOpenButton = styled(BasicButtonEl)`
   display: inline-block;
   background: url(${MenuIcon});
   background-size: cover;

--- a/src/popup/components/index.tsx
+++ b/src/popup/components/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
-import { BasicButtonEl } from "popup/basics";
+import { BasicButton } from "popup/basics";
 
 const ErrorEl = styled.p`
   color: red;
@@ -16,7 +16,7 @@ export const ErrorMessage = ({ authError }: ErrorMessageProps) => (
   <>{authError ? <ErrorEl>{authError}</ErrorEl> : null}</>
 );
 
-export const FormButton = styled(BasicButtonEl)`
+export const FormButton = styled(BasicButton)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 1.5rem;
   color: #fff;

--- a/src/popup/components/index.tsx
+++ b/src/popup/components/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
-import { Button } from "popup/basics";
+import { BasicButtonEl } from "popup/basics";
 
 const ErrorEl = styled.p`
   color: red;
@@ -16,7 +16,7 @@ export const ErrorMessage = ({ authError }: ErrorMessageProps) => (
   <>{authError ? <ErrorEl>{authError}</ErrorEl> : null}</>
 );
 
-export const FormButton = styled(Button)`
+export const FormButton = styled(BasicButtonEl)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 1.5rem;
   color: #fff;

--- a/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
@@ -8,7 +8,7 @@ import {
 } from "popup/ducks/authServices";
 import Form from "popup/components/Form";
 import { COLOR_PALETTE } from "popup/styles";
-import { ApiErrorMessage, Button } from "popup/basics";
+import { ApiErrorMessage, BasicButtonEl } from "popup/basics";
 import CheckButton from "./basics/CheckButton";
 
 const ConfirmInput = styled.div`
@@ -26,7 +26,7 @@ const ConfirmInput = styled.div`
   text-align: center;
 `;
 
-const ClearButton = styled(Button)`
+const ClearButton = styled(BasicButtonEl)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 7px;
   color: #fff;

--- a/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
@@ -8,7 +8,7 @@ import {
 } from "popup/ducks/authServices";
 import Form from "popup/components/Form";
 import { COLOR_PALETTE } from "popup/styles";
-import { ApiErrorMessage, BasicButtonEl } from "popup/basics";
+import { ApiErrorMessage, BasicButton } from "popup/basics";
 import CheckButton from "./basics/CheckButton";
 
 const ConfirmInput = styled.div`
@@ -26,7 +26,7 @@ const ConfirmInput = styled.div`
   text-align: center;
 `;
 
-const ClearButton = styled(BasicButtonEl)`
+const ClearButton = styled(BasicButton)`
   background: ${COLOR_PALETTE.primaryGradient};
   border-radius: 7px;
   color: #fff;

--- a/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
 import Download from "popup/assets/download.png";
 import Copy from "popup/assets/copy.png";
-import { Button, FormButton } from "popup/basics";
+import { BasicButtonEl, FormButton } from "popup/basics";
 import Toast from "popup/components/Toast";
 import ActionButton from "./basics/ActionButton";
 
@@ -27,7 +27,7 @@ const MnemonicDisplay = styled.div`
     isBlurred ? "0 0 5px rgba(0, 0, 0, 0.5)" : "none"};
 `;
 
-const DisplayTooltip = styled(Button)`
+const DisplayTooltip = styled(BasicButtonEl)`
   color: #fff;
   font-size: 1rem;
   position: absolute;

--- a/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
 import Download from "popup/assets/download.png";
 import Copy from "popup/assets/copy.png";
-import { BasicButtonEl, FormButton } from "popup/basics";
+import { BasicButton, FormButton } from "popup/basics";
 import Toast from "popup/components/Toast";
 import ActionButton from "./basics/ActionButton";
 
@@ -27,7 +27,7 @@ const MnemonicDisplay = styled.div`
     isBlurred ? "0 0 5px rgba(0, 0, 0, 0.5)" : "none"};
 `;
 
-const DisplayTooltip = styled(BasicButtonEl)`
+const DisplayTooltip = styled(BasicButton)`
   color: #fff;
   font-size: 1rem;
   position: absolute;

--- a/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
+++ b/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { BasicButtonEl } from "popup/basics";
+import { BasicButton } from "popup/basics";
 import { COLOR_PALETTE } from "popup/styles";
 
-const ActionButton = styled(BasicButtonEl)`
+const ActionButton = styled(BasicButton)`
   color: ${COLOR_PALETTE.secondaryText};
   font-size: 0.875rem;
   font-weight: 500;

--- a/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
+++ b/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { Button } from "popup/basics";
+import { BasicButtonEl } from "popup/basics";
 import { COLOR_PALETTE } from "popup/styles";
 
-const ActionButton = styled(Button)`
+const ActionButton = styled(BasicButtonEl)`
   color: ${COLOR_PALETTE.secondaryText};
   font-size: 0.875rem;
   font-weight: 500;

--- a/src/popup/styles/index.tsx
+++ b/src/popup/styles/index.tsx
@@ -1,16 +1,24 @@
 export const COLOR_PALETTE = {
+  white: "#fff",
   background: "#F0F2F6",
+  inputBackground: "rgba(210, 216, 229, 0.4)",
   text: "#060E1A",
   secondaryText: "#748098",
   primary: "#391EDA",
-  primaryGradient: "linear-gradient(90deg, #391EDA 100%, #5339ED 0%)",
-  menuGradient: "linear-gradient(180deg, #564df0 0%,#2d18b5 100%)",
   secondary: "#654CF7",
   error: "#F42703",
-  inputBackground: "rgba(210, 216, 229, 0.4)",
+  primaryGradient: "linear-gradient(180deg, #4b42e3 0%, #302cd1 100%)",
+  menuGradient: "linear-gradient(180deg, #564df0 0%, #2d18b5 100%)",
+  warningGradient: "linear-gradient(180deg, #ed5c40 0%, #e33d24 100%)",
 };
 
 export const Z_INDEXES = {
   body: 0,
   nav: 10,
+};
+
+export const FONT_WEIGHT = {
+  light: "300",
+  normal: "400",
+  bold: "600",
 };

--- a/src/popup/views/Account/index.tsx
+++ b/src/popup/views/Account/index.tsx
@@ -5,7 +5,7 @@ import { publicKeySelector } from "popup/ducks/authServices";
 import { useSelector } from "react-redux";
 import { getAccountBalance } from "api/internal";
 import { COLOR_PALETTE } from "popup/styles";
-import { BasicButtonEl } from "popup/basics";
+import { BasicButton } from "popup/basics";
 import Toast from "popup/components/Toast";
 import CopyColor from "popup/assets/copy-color.png";
 import StellarLogo from "popup/assets/stellar-logo.png";
@@ -28,7 +28,7 @@ const PublicKeyEl = styled.span`
   opacity: 0.7;
 `;
 
-const CopyButton = styled(BasicButtonEl)`
+const CopyButton = styled(BasicButton)`
   background: url(${CopyColor});
   background-size: cover;
   width: 1rem;

--- a/src/popup/views/Account/index.tsx
+++ b/src/popup/views/Account/index.tsx
@@ -5,7 +5,7 @@ import { publicKeySelector } from "popup/ducks/authServices";
 import { useSelector } from "react-redux";
 import { getAccountBalance } from "api/internal";
 import { COLOR_PALETTE } from "popup/styles";
-import { Button } from "popup/basics";
+import { BasicButtonEl } from "popup/basics";
 import Toast from "popup/components/Toast";
 import CopyColor from "popup/assets/copy-color.png";
 import StellarLogo from "popup/assets/stellar-logo.png";
@@ -28,7 +28,7 @@ const PublicKeyEl = styled.span`
   opacity: 0.7;
 `;
 
-const CopyButton = styled(Button)`
+const CopyButton = styled(BasicButtonEl)`
   background: url(${CopyColor});
   background-size: cover;
   width: 1rem;

--- a/src/popup/views/GrantAccess/index.tsx
+++ b/src/popup/views/GrantAccess/index.tsx
@@ -10,12 +10,12 @@ import { Button } from "popup/basics";
 const GrantAccessEl = styled.div`
   padding: 2.25rem 2.5rem;
 `;
-const H1 = styled.h1`
+const Header = styled.h1`
   color: ${COLOR_PALETTE.primary}};
   font-weight: ${FONT_WEIGHT.light};
   margin: 1rem 0 0.75rem;
 `;
-const H3 = styled.h3`
+const Subheader = styled.h3`
   font-weight: ${FONT_WEIGHT.bold};
   font-size: 0.95rem;
   letter-spacing: 0.1px;
@@ -55,8 +55,8 @@ export const GrantAccess = () => {
 
   return (
     <GrantAccessEl>
-      <H1>Connection request</H1>
-      <H3>{title} wants to know your public key</H3>
+      <Header>Connection request</Header>
+      <Subheader>{title} wants to know your public key</Subheader>
       <Text>
         This site is asking for access to the public key associated with this
         Lyra wallet. Only share your information with websites you trust.{" "}

--- a/src/popup/views/GrantAccess/index.tsx
+++ b/src/popup/views/GrantAccess/index.tsx
@@ -1,8 +1,43 @@
 import React from "react";
+import styled from "styled-components";
 import { useLocation } from "react-router-dom";
+
 import { rejectAccess, grantAccess } from "api/internal";
 
-const GrantAccess = () => {
+import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
+import { Button } from "popup/basics";
+
+const GrantAccessEl = styled.div`
+  padding: 2.25rem 2.5rem;
+`;
+const H1 = styled.h1`
+  color: ${COLOR_PALETTE.primary}};
+  font-weight: ${FONT_WEIGHT.light};
+  margin: 1rem 0 0.75rem;
+`;
+const H3 = styled.h3`
+  font-weight: ${FONT_WEIGHT.bold};
+  font-size: 0.95rem;
+  letter-spacing: 0.1px;
+  color: ${COLOR_PALETTE.primary}};
+`;
+const Text = styled.p`
+  font-size: 1.15rem;
+  text-align: center;
+  line-height: 1.9;
+  padding: 1.7rem 2rem;
+  margin: 0;
+`;
+const ButtonContainerEl = styled.div`
+  display: flex;
+  justify-content: space-around;
+  padding: 3rem 1.25rem;
+`;
+const RejectButton = styled(Button)`
+  background: ${COLOR_PALETTE.text};
+`;
+
+export const GrantAccess = () => {
   const location = useLocation();
   const decodedTab = atob(location.search.replace("?", ""));
   const tabToUnlock = decodedTab ? JSON.parse(decodedTab) : {};
@@ -19,21 +54,21 @@ const GrantAccess = () => {
   };
 
   return (
-    <>
-      <h1>Connection request</h1>
-      <img alt="favicon of site" src={`${url}/favico.png`} />
-      <h3>{title}</h3>
-      <h3>{url}</h3>
-
-      <h3>{title} wants to know your public key</h3>
-      <p>
+    <GrantAccessEl>
+      <H1>Connection request</H1>
+      <H3>{title} wants to know your public key</H3>
+      <Text>
         This site is asking for access to the public key associated with this
         Lyra wallet. Only share your information with websites you trust.{" "}
-      </p>
-      <button onClick={() => rejectAndClose()}>Reject</button>
-      <button onClick={() => grantAndClose()}>Connect</button>
-    </>
+      </Text>
+      <ButtonContainerEl>
+        <RejectButton size="small" onClick={() => rejectAndClose()}>
+          Reject
+        </RejectButton>
+        <Button size="small" onClick={() => grantAndClose()}>
+          Connect
+        </Button>
+      </ButtonContainerEl>
+    </GrantAccessEl>
   );
 };
-
-export default GrantAccess;


### PR DESCRIPTION
Ticket: [[UI] Sign in to third party-services using Lyra](https://app.asana.com/0/1168666457741233/1168291088234545)
- Also added styles for all the buttons regarding its size (primary vs. small) and colors (warning vs. black vs. primary)

Preview:
* Overall Page
<img width="456" alt="preview" src="https://user-images.githubusercontent.com/3912060/84436390-5dfc9300-ac01-11ea-8a34-838428cd63f3.png">

* Buttons
<img width="236" alt="primary-buttons" src="https://user-images.githubusercontent.com/3912060/84436399-60f78380-ac01-11ea-9d80-7edf5f796fa6.png">
<img width="356" alt="small-buttons" src="https://user-images.githubusercontent.com/3912060/84436400-60f78380-ac01-11ea-867c-9f4306c6eebd.png">

- There is a `prop` for `size`. **But** for colors, I didn't add props for. For `<GrantAccess/>`, we extended an existing style `Button` and created `RejectButton` styled component to style it with a black background

- I renamed `Button` in `src/popup/basics/index.tsx` to `BasicButton` since it's being used in a lot of places but I took `Button` for the all the styled buttons. Let me know if we want to change this to something else.