### PR TITLE
Emojis moved to its own file; <UnlockAccount/> added using Formik

### DIFF
--- a/src/popup/Router.tsx
+++ b/src/popup/Router.tsx
@@ -25,7 +25,7 @@ import MnemonicPhrase from "popup/views/MnemonicPhrase";
 import MnemonicPhraseConfirmed from "popup/views/MnemonicPhrase/Confirmed";
 import RecoverAccount from "popup/views/RecoverAccount";
 import SignTransaction from "popup/views/SignTransaction";
-import UnlockAccount from "popup/views/UnlockAccount";
+import { UnlockAccount } from "popup/views/UnlockAccount";
 import Welcome from "popup/views/Welcome";
 
 const Loading = () => <p> Loading...</p>;

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -22,7 +22,7 @@ export const BasicButton = styled.button`
 
 interface ButtonProps {
   size?: string;
-  onClick(): any;
+  onClick?: () => void;
   children: React.ReactNode;
 }
 
@@ -33,7 +33,7 @@ export const ButtonEl = styled.button<ButtonProps>`
   font-size: 0.8rem;
   font-weight: ${FONT_WEIGHT.bold};
   padding: 1.45rem;
-  border-radius: 20px;
+  border-radius: 1.25rem;
   background: ${COLOR_PALETTE.primaryGradient};
   color: ${COLOR_PALETTE.white};
   border: none;
@@ -42,7 +42,7 @@ export const ButtonEl = styled.button<ButtonProps>`
 `;
 
 export const Button = ({ size, children, onClick, ...props }: ButtonProps) => (
-  <ButtonEl size={size} onClick={onClick} {...props}>
+  <ButtonEl size={size} onClick={() => onClick && onClick()} {...props}>
     {children}
   </ButtonEl>
 );
@@ -52,7 +52,7 @@ interface ErrorMessageProps {
   error: string;
 }
 
-const FormErrorEl = styled.div`
+export const FormErrorEl = styled.div`
   color: ${COLOR_PALETTE.error};
   font-size: 0.8125rem;
   height: 1rem;
@@ -98,17 +98,7 @@ export const ApiErrorMessage = ({ error }: ErrorMessageProps) => (
   <>{error ? <FormErrorEl>{error}</FormErrorEl> : null}</>
 );
 
-export const FormButton = styled(BasicButton)`
-  background: ${COLOR_PALETTE.primaryGradient};
-  border-radius: 1.5rem;
-  color: ${COLOR_PALETTE.white};
-  display: block;
-  font-size: 1.1rem;
-  font-weight: 600;
-  line-height: 1.3rem;
-  margin: 1.5rem auto;
-  padding: 1.6rem 6rem;
-
+export const FormButton = styled(ButtonEl)`
   &:disabled {
     color: ${COLOR_PALETTE.secondaryText};
   }
@@ -132,8 +122,10 @@ export const FormSubmitButton = ({
 );
 
 export const FormRow = styled.div`
+  position: relative;
   padding: 0.2rem 0;
-  width: 24.5rem;
+  max-width: 24.5rem;
+  width: 100%;
 `;
 
 export const FormError = ({ name }: { name: string }) => (
@@ -143,12 +135,13 @@ export const FormError = ({ name }: { name: string }) => (
 );
 
 export const FormTextField = styled(Field)`
-  border-radius: 1.875rem;
-  border: 0;
+  border-radius: 1.25rem;
+  border: ${(props) =>
+    props.hasError ? `1px solid ${COLOR_PALETTE.error}` : 0};
   box-sizing: border-box;
   background: ${COLOR_PALETTE.inputBackground};
-  font-size: 1.125rem;
-  padding: 1.875rem 3rem;
+  font-size: 1rem;
+  padding: 1.875rem 2.25rem;
   width: 100%;
 `;
 

--- a/src/popup/constants/index.ts
+++ b/src/popup/constants/index.ts
@@ -1,1 +1,21 @@
 export const POPUP_WIDTH = 456;
+
+export const EMOJI = {
+  spy: {
+    emoji: "🕵",
+    alt: "Spy",
+  },
+  see_no_evil: { emoji: "🙈", alt: "See No Evil" },
+  wave: {
+    emoji: "👋🏼",
+    alt: "wave",
+  },
+  poop: {
+    emoji: "💩",
+    alt: "poop",
+  },
+  vomit: {
+    emoji: "🤮",
+    alt: "vomit",
+  },
+};

--- a/src/popup/ducks/authServices.ts
+++ b/src/popup/ducks/authServices.ts
@@ -110,7 +110,7 @@ export const confirmPassword = createAsyncThunk<
   }
   if (!res.publicKey) {
     return thunkApi.rejectWithValue({
-      errorMessage: "The password you entered is incorrect",
+      errorMessage: "Incorrect Password",
     });
   }
 

--- a/src/popup/views/CreatePassword/index.tsx
+++ b/src/popup/views/CreatePassword/index.tsx
@@ -18,6 +18,7 @@ import {
   confirmPassword as confirmPasswordValidator,
   termsOfUse as termsofUseValidator,
 } from "popup/components/Form/validators";
+import { EMOJI } from "popup/constants";
 import { history } from "popup/App";
 
 const CreatePassword = () => {
@@ -52,16 +53,11 @@ const CreatePassword = () => {
     }
   }, [publicKey]);
 
-  const icon = {
-    emoji: "🙈",
-    alt: "See No Evil",
-  };
-
   return (
     <Onboarding
       header="Create a password"
       subheader="Min 10 characters"
-      icon={icon}
+      icon={EMOJI.see_no_evil}
       goBack={() => window.location.replace("/")}
     >
       <Formik
@@ -81,7 +77,6 @@ const CreatePassword = () => {
                 />
                 <FormError name="password" />
               </FormRow>
-
               <FormRow>
                 <FormTextField
                   autoComplete="off"

--- a/src/popup/views/MnemonicPhrase/index.tsx
+++ b/src/popup/views/MnemonicPhrase/index.tsx
@@ -1,31 +1,31 @@
 import React, { useState } from "react";
 import { shuffle } from "lodash";
-import ConfirmMnemonicPhrase from "popup/components/mnemonicPhrase/ConfirmMnemonicPhrase";
+
+import { EMOJI } from "popup/constants";
+
 import useMnemonicPhrase from "popup/hooks/useMnemonicPhrase";
-import DisplayMnemonicPhrase from "popup/components/mnemonicPhrase/DisplayMnemonicPhrase";
+
 import { Onboarding } from "popup/components/Layout/Fullscreen/Onboarding";
+
+import ConfirmMnemonicPhrase from "popup/components/mnemonicPhrase/ConfirmMnemonicPhrase";
+import DisplayMnemonicPhrase from "popup/components/mnemonicPhrase/DisplayMnemonicPhrase";
 
 const MnemonicPhrase = () => {
   const [readyToConfirm, setReadyToConfirm] = useState(false);
 
   const mnemonicPhrase = useMnemonicPhrase();
 
-  const icon = {
-    emoji: "🕵️‍♂️",
-    alt: "Spy",
-  };
-
   if (mnemonicPhrase) {
     return readyToConfirm ? (
       <Onboarding
         header="Confirm your secret phrase"
-        icon={icon}
+        icon={EMOJI.spy}
         goBack={() => setReadyToConfirm(false)}
       >
         <ConfirmMnemonicPhrase words={shuffle(mnemonicPhrase.split(" "))} />
       </Onboarding>
     ) : (
-      <Onboarding header="Secret backup phrase" icon={icon}>
+      <Onboarding header="Secret backup phrase" icon={EMOJI.spy}>
         <DisplayMnemonicPhrase
           mnemonicPhrase={mnemonicPhrase}
           setReadyToConfirm={setReadyToConfirm}

--- a/src/popup/views/UnlockAccount/index.tsx
+++ b/src/popup/views/UnlockAccount/index.tsx
@@ -1,55 +1,153 @@
-import React, { useState } from "react";
+import React from "react";
 import { get } from "lodash";
-import { history } from "popup/App";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
-import { confirmPassword, authErrorSelector } from "popup/ducks/authServices";
+import { useLocation, Link } from "react-router-dom";
+import styled from "styled-components";
+import { Formik } from "formik";
 
-const UnlockAccount = () => {
+import { confirmPassword, authErrorSelector } from "popup/ducks/authServices";
+import { history } from "popup/App";
+
+import { POPUP_WIDTH, EMOJI } from "popup/constants";
+import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
+
+import {
+  FormSubmitButton,
+  FormRow,
+  FormErrorEl,
+  FormTextField,
+} from "popup/basics";
+
+import Form from "popup/components/Form";
+
+const UnlockAccountEl = styled.div`
+  width: 100%;
+  max-width: ${POPUP_WIDTH}px;
+  box-sizing: border-box;
+  padding: 2rem 2.5rem;
+`;
+const HeaderContainerEl = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 2.5rem 0.25rem;
+  line-height: 1;
+`;
+const HeaderEl = styled.h1`
+  display: inline-block;
+  color: ${COLOR_PALETTE.primary}};
+  font-weight: ${FONT_WEIGHT.light};
+  margin: 0;
+  margin-left: 1rem;
+`;
+const StyledLinkEl = styled(Link)`
+  color: ${COLOR_PALETTE.primary};
+`;
+const UnorderedListEl = styled.ul`
+  list-style-type: none;
+  font-size: 0.8rem;
+  text-align: center;
+  margin: 0 auto;
+  padding: 0;
+  padding-top: 0.25rem;
+`;
+const CustomFormTextField = styled(FormTextField)`
+  padding-right: ${(props) => (props.hasError ? "6rem" : "2.2rem")};
+`;
+const ListItemEl = styled.li`
+  color: ${COLOR_PALETTE.secondaryText};
+  padding: 0.5rem 0;
+  line-height: 1;
+`;
+const ButtonRow = styled.div`
+  padding: 1.5rem 0;
+`;
+const EmojiSpan = styled.span`
+  font-size: 3rem;
+`;
+const ErrorEmojiEl = styled.div`
+  position: absolute;
+  right: 2rem;
+  top: 50%;
+  transform: translateY(-50%);
+
+  ${EmojiSpan} {
+    font-size: 1.75rem;
+  }
+`;
+
+export const UnlockAccount = () => {
   const location = useLocation();
   const from = get(location, "state.from.pathname", "");
   const queryParams = get(location, "search", "");
   const destination = from ? `${from}${queryParams}` : "/account";
 
-  const [password, setPassword] = useState("");
   const dispatch = useDispatch();
+  const authError = useSelector(authErrorSelector);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  interface FormValues {
+    password: string;
+  }
+  const initialValues: FormValues = {
+    password: "",
+  };
+
+  const handleSubmit = async (values: FormValues) => {
+    const { password } = values;
     await dispatch(confirmPassword(password));
     history.push(destination);
   };
 
-  const authError = useSelector(authErrorSelector);
-
   return (
-    <>
-      <form onSubmit={handleSubmit}>
-        <ul>
-          <li>
-            <input
-              type="text"
-              onChange={(e) => {
-                setPassword(e.target.value);
-              }}
-            />
-          </li>
-          <li>{authError ? <label>{authError}</label> : null}</li>
-          <li>
-            <button type="submit">Log In</button>
-          </li>
-        </ul>
-      </form>
-      <ul>
-        <li>
-          <a href="/">Help</a>
-        </li>
-        <li>
-          <a href="/">Recover account from backup phrase</a>
-        </li>
-      </ul>
-    </>
+    <UnlockAccountEl>
+      <Formik onSubmit={handleSubmit} initialValues={initialValues}>
+        {({ isSubmitting, isValid }) => (
+          <Form>
+            <HeaderContainerEl>
+              <EmojiSpan role="img" aria-label={EMOJI.wave.alt}>
+                {EMOJI.wave.emoji}
+              </EmojiSpan>
+              <HeaderEl>Welcome back!</HeaderEl>
+            </HeaderContainerEl>
+            <FormRow>
+              <CustomFormTextField
+                autoComplete="off"
+                type="password"
+                name="password"
+                placeholder="Enter password"
+                hasError={authError && "1px solid red"}
+              />
+              {authError ? (
+                <ErrorEmojiEl>
+                  <EmojiSpan role="img" aria-label={EMOJI.vomit.alt}>
+                    {EMOJI.vomit.emoji}
+                  </EmojiSpan>
+                  <EmojiSpan role="img" aria-label={EMOJI.poop.alt}>
+                    {EMOJI.poop.emoji}
+                  </EmojiSpan>
+                </ErrorEmojiEl>
+              ) : null}
+            </FormRow>
+            <FormErrorEl>
+              {authError ? <label>{authError}</label> : null}
+            </FormErrorEl>
+            <ButtonRow>
+              <FormSubmitButton
+                buttonCTA="Log In"
+                isSubmitting={isSubmitting}
+                isValid={isValid}
+              />
+            </ButtonRow>
+          </Form>
+        )}
+      </Formik>
+      <UnorderedListEl>
+        <ListItemEl>Want to add another account?</ListItemEl>
+        <ListItemEl>
+          <StyledLinkEl to="/recover-account">
+            Import using account see phrase
+          </StyledLinkEl>
+        </ListItemEl>
+      </UnorderedListEl>
+    </UnlockAccountEl>
   );
 };
-
-export default UnlockAccount;

--- a/src/popup/views/UnlockAccount/index.tsx
+++ b/src/popup/views/UnlockAccount/index.tsx
@@ -114,7 +114,7 @@ export const UnlockAccount = () => {
                 type="password"
                 name="password"
                 placeholder="Enter password"
-                hasError={authError && "1px solid red"}
+                hasError={authError}
               />
               {authError ? (
                 <ErrorEmojiEl>


### PR DESCRIPTION
Ticket: [Log in to an account on a browser where user was authenticated before](https://app.asana.com/0/1168666457741233/1168291088234568)

**Preview Images:**
Without an error
<img width="457" alt="lyra-unlock-account" src="https://user-images.githubusercontent.com/3912060/84828004-553a0180-aff3-11ea-8934-4c4f7b4983de.png">

With an error
<img width="457" alt="lyra-unlock-account-error" src="https://user-images.githubusercontent.com/3912060/84828006-55d29800-aff3-11ea-8c7d-9c86ea9c542c.png">

Other big changes:
- Aggregated emojis in `src/popup/constants/index.ts`
- Converting its previous form to use Formik to match the others.
- Changed `FormButton` to adapt the `ButtonEl` to match the styling
- Added comments in files