### PR TITLE
Added UI for <SignTransaction/>; removed memo for now; added BigNumber library

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@reduxjs/toolkit": "^1.3.5",
     "@stellar/wallet-sdk": "^0.0.9-rc.7",
     "@types/yup": "^0.29.2",
+    "bignumber.js": "^9.0.0",
     "buffer": "^5.6.0",
     "eslint-loader": "^4.0.2",
     "fetch": "^1.1.0",

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,2 +1,4 @@
 export const newTabHref = (path = "") => `index.html#${path}`;
 export const removeQueryParam = (url = "") => url.replace(/\?(.*)/, "");
+export const truncatedPublicKey = (publicKey: string) =>
+  `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`;

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -23,6 +23,7 @@ const GlobalStyle = createGlobalStyle`
 
   body, html {
     width: ${POPUP_WIDTH}px;
+  }
   body, html, #root {
     height: 100vh;
   }

--- a/src/popup/Router.tsx
+++ b/src/popup/Router.tsx
@@ -24,7 +24,7 @@ import { GrantAccess } from "popup/views/GrantAccess";
 import MnemonicPhrase from "popup/views/MnemonicPhrase";
 import MnemonicPhraseConfirmed from "popup/views/MnemonicPhrase/Confirmed";
 import RecoverAccount from "popup/views/RecoverAccount";
-import SignTransaction from "popup/views/SignTransaction";
+import { SignTransaction } from "popup/views/SignTransaction";
 import { UnlockAccount } from "popup/views/UnlockAccount";
 import Welcome from "popup/views/Welcome";
 

--- a/src/popup/assets/icon-chevron.svg
+++ b/src/popup/assets/icon-chevron.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="9" height="10" viewBox="0 0 9 10">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#333" fill-rule="nonzero" d="M5.785 4.621l-3.35 3.403a.65.65 0 0 0 0 .909.626.626 0 0 0 .895 0l3.797-3.857a.65.65 0 0 0 0-.91L3.33.31a.626.626 0 0 0-.895 0 .65.65 0 0 0 0 .909l3.35 3.402z"/>
+    </g>
+</svg>

--- a/src/popup/assets/icon-chevron.svg
+++ b/src/popup/assets/icon-chevron.svg
@@ -1,5 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="9" height="10" viewBox="0 0 9 10">
-    <g fill="none" fill-rule="evenodd">
-        <path fill="#333" fill-rule="nonzero" d="M5.785 4.621l-3.35 3.403a.65.65 0 0 0 0 .909.626.626 0 0 0 .895 0l3.797-3.857a.65.65 0 0 0 0-.91L3.33.31a.626.626 0 0 0-.895 0 .65.65 0 0 0 0 .909l3.35 3.402z"/>
-    </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5.7 9.4"><path d="M3.8 4.6L.5 8c-.2.3-.2.7 0 .9.2.2.6.3.9 0L5.2 5c.2-.3.2-.7 0-.9L1.4.3C1.2.1.8 0 .5.3c-.2.3-.2.7 0 .9l3.3 3.4z" fill="#748098"/></svg>

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -55,6 +55,7 @@ interface BackButtonProps {
 }
 
 const BackButtonEl = styled.button`
+  cursor: pointer;
   display: flex;
   align-items: center;
   background: ${COLOR_PALETTE.inputBackground};

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -28,7 +28,7 @@ interface ButtonProps {
   children: React.ReactNode;
 }
 
-export const ButtonEl = styled.button<ButtonProps>`
+export const ButtonEl = styled(BasicButton)<ButtonProps>`
   width: ${(props) => (props.size === "small" ? "8.75rem" : "12.375rem")};
   display: ${(props) => (props.size === "small" ? "inline-block" : "block")};
   margin: 0 auto;
@@ -39,7 +39,6 @@ export const ButtonEl = styled.button<ButtonProps>`
   background: ${COLOR_PALETTE.primaryGradient};
   color: ${COLOR_PALETTE.white};
   border: none;
-  cursor: pointer;
   -webkit-appearance: none;
 `;
 
@@ -54,12 +53,10 @@ interface BackButtonProps {
   onClick: () => void;
 }
 
-const BackButtonEl = styled.button`
-  cursor: pointer;
+const BackButtonEl = styled(BasicButton)`
   display: flex;
   align-items: center;
   background: ${COLOR_PALETTE.inputBackground};
-  border: none;
   border-radius: 0.625rem;
   justify-content: center;
   width: 2.5rem;

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -4,6 +4,8 @@ import { ErrorMessage, Field } from "formik";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
 
+import ChevronIcon from "popup/assets/icon-chevron.svg";
+
 /* Button */
 export const BasicButton = styled.button`
   background: none;
@@ -45,6 +47,34 @@ export const Button = ({ size, children, onClick, ...props }: ButtonProps) => (
   <ButtonEl size={size} onClick={() => onClick && onClick()} {...props}>
     {children}
   </ButtonEl>
+);
+
+/* Back Button */
+interface BackButtonProps {
+  onClick: () => void;
+}
+
+const BackButtonEl = styled.button`
+  display: flex;
+  align-items: center;
+  background: ${COLOR_PALETTE.inputBackground};
+  border: none;
+  border-radius: 0.625rem;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+
+  img {
+    transform: rotate(180deg);
+    width: 0.8rem;
+    height: 0.8rem;
+  }
+`;
+
+export const BackButton = ({ onClick, ...props }: BackButtonProps) => (
+  <BackButtonEl onClick={() => onClick && onClick()} {...props}>
+    <img src={ChevronIcon} alt="chevron icon" />
+  </BackButtonEl>
 );
 
 /* Form */

--- a/src/popup/components/Layout/Fullscreen/Onboarding.tsx
+++ b/src/popup/components/Layout/Fullscreen/Onboarding.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
-import { BasicButton } from "popup/basics";
+import { BackButton } from "popup/basics";
 import { FullscreenStyle } from "./basics/FullscreenStyle";
 
 const HeaderEl = styled.h1`
@@ -38,11 +38,6 @@ const EmojiSpan = styled.span`
   font-size: 3.625rem;
 `;
 
-const BackButton = styled(BasicButton)`
-  margin: 1rem 0 0 2.75rem;
-  text-align: left;
-`;
-
 export const Onboarding = ({
   goBack,
   header,
@@ -58,7 +53,7 @@ export const Onboarding = ({
 }) => (
   <>
     <FullscreenStyle />
-    {goBack ? <BackButton onClick={goBack}>&lt; Back</BackButton> : null}
+    {goBack ? <BackButton onClick={goBack} /> : null}
     <Screen>
       <EmojiSpan role="img" aria-label={alt}>
         {emoji}

--- a/src/popup/views/Account/index.tsx
+++ b/src/popup/views/Account/index.tsx
@@ -1,14 +1,20 @@
 import React, { useEffect, useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import styled from "styled-components";
-import { publicKeySelector } from "popup/ducks/authServices";
 import { useSelector } from "react-redux";
+
 import { getAccountBalance } from "api/internal";
+
+import { truncatedPublicKey } from "helpers";
+import { publicKeySelector } from "popup/ducks/authServices";
 import { COLOR_PALETTE } from "popup/styles";
 import { BasicButton } from "popup/basics";
+
 import Toast from "popup/components/Toast";
+
 import CopyColor from "popup/assets/copy-color.png";
 import StellarLogo from "popup/assets/stellar-logo.png";
+
 import Footer from "./basics/Footer";
 
 const PublicKeyDisplay = styled.div`
@@ -57,9 +63,6 @@ const LumenBalance = styled.h2`
 const CopiedToastWrapper = styled.div`
   margin: 0.3rem 0 0 -5rem;
 `;
-
-const truncatedPublicKey = (publicKey: string) =>
-  `${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`;
 
 const Account = () => {
   const [accountBalance, setaccountBalance] = useState("");

--- a/src/popup/views/SignTransaction/index.tsx
+++ b/src/popup/views/SignTransaction/index.tsx
@@ -12,7 +12,7 @@ import { truncatedPublicKey } from "helpers";
 
 import { publicKeySelector } from "popup/ducks/authServices";
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
-import { Button } from "popup/basics";
+import { Button, BackButton } from "popup/basics";
 
 const El = styled.div`
   padding: 2.25rem 2.5rem;
@@ -215,6 +215,7 @@ export const SignTransaction = () => {
 
   return (
     <El>
+      <BackButton onClick={() => window.location.replace("/")} />
       <Header>Confirm Transaction</Header>
       <Subheader>{title} is requesting a transaction</Subheader>
       {/* <Subheader>Transaction details</Subheader> */}

--- a/src/popup/views/SignTransaction/index.tsx
+++ b/src/popup/views/SignTransaction/index.tsx
@@ -118,6 +118,21 @@ export const SignTransaction = () => {
     price: string;
   }
 
+  const KeyValueList = ({
+    TransactionInfoKey,
+    TransactionInfoValue,
+  }: {
+    TransactionInfoKey: string;
+    TransactionInfoValue: string | number;
+  }) => (
+    <li>
+      <div>
+        <strong>{TransactionInfoKey}</strong>
+      </div>
+      <div>{TransactionInfoValue}</div>
+    </li>
+  );
+
   const Operations = () =>
     _operations.map(
       (
@@ -145,76 +160,60 @@ export const SignTransaction = () => {
             </OperationBoxHeader>
             <ListEl>
               {amount ? (
-                <li>
-                  <div>
-                    <strong>Amount</strong>
-                  </div>
-                  <div>
-                    {formattedAmount} {asset.code}
-                  </div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Amount"
+                  TransactionInfoValue={`${formattedAmount} ${asset.code}`}
+                />
               ) : null}
 
               {destination ? (
-                <li>
-                  <div>
-                    <strong>Destination</strong>
-                  </div>
-                  <div>{truncatedPublicKey(destination)}</div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Destination"
+                  TransactionInfoValue={truncatedPublicKey(destination)}
+                />
               ) : null}
 
               {signer ? (
                 <>
-                  <li>
-                    <div>
-                      <strong>Signer</strong>
-                    </div>
-                    <div>{truncatedPublicKey(signer.ed25519PublicKey)}</div>
-                  </li>
-                  <li>
-                    <div>
-                      <strong>Weight</strong>
-                    </div>
-                    <div>{signer.weight}</div>
-                  </li>
+                  <KeyValueList
+                    TransactionInfoKey="Signer"
+                    TransactionInfoValue={truncatedPublicKey(
+                      signer.ed25519PublicKey,
+                    )}
+                  />
+                  <KeyValueList
+                    TransactionInfoKey="Weight"
+                    TransactionInfoValue={signer.weight}
+                  />
                 </>
               ) : null}
 
               {buying ? (
-                <li>
-                  <div>
-                    <strong>Buying</strong>
-                  </div>
-                  <div> {buying.code}</div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Buying"
+                  TransactionInfoValue={buying.code}
+                />
               ) : null}
 
               {selling ? (
-                <li>
-                  <div>
-                    <strong>Selling</strong>
-                  </div>
-                  <div>{selling.code}</div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Selling"
+                  TransactionInfoValue={selling.code}
+                />
               ) : null}
 
               {buyAmount ? (
-                <li>
-                  <div>
-                    <strong>Amount</strong>
-                  </div>
-                  <div>{formattedBuyAmount}</div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Amount"
+                  TransactionInfoValue={formattedBuyAmount}
+                />
               ) : null}
 
               {price ? (
-                <li>
-                  <div>
-                    <strong>Price</strong>
-                  </div>
-                  <div> {price}</div>
-                </li>
+                <KeyValueList
+                  TransactionInfoKey="Price"
+                  TransactionInfoValue={price}
+                />
               ) : null}
             </ListEl>
           </OperationBox>

--- a/src/popup/views/SignTransaction/index.tsx
+++ b/src/popup/views/SignTransaction/index.tsx
@@ -103,36 +103,45 @@ export const SignTransaction = () => {
     window.close();
   };
 
+  interface TransactionInfoResponse {
+    amount: string;
+    destination: string;
+    asset: { code: string };
+    signer: {
+      ed25519PublicKey: string;
+      weight: number;
+    };
+    type: keyof typeof operationTypes;
+    buying: { code: string };
+    selling: { code: string };
+    buyAmount: string;
+    price: string;
+  }
+
   const Operations = () =>
     _operations.map(
-      ({
-        amount,
-        destination,
-        asset,
-        signer,
-        type,
-        buying,
-        selling,
-        buyAmount,
-        price,
-      }: {
-        amount: string;
-        destination: string;
-        asset: { code: string };
-        signer: { ed25519PublicKey: string; weight: number };
-        type: keyof typeof operationTypes;
-        buying: { code: string };
-        selling: { code: string };
-        buyAmount: string;
-        price: string;
-      }) => {
+      (
+        {
+          amount,
+          destination,
+          asset,
+          signer,
+          type,
+          buying,
+          selling,
+          buyAmount,
+          price,
+        }: TransactionInfoResponse,
+        i: number,
+      ) => {
         const formattedAmount = new BigNumber(amount).toFormat(2);
         const formattedBuyAmount = new BigNumber(buyAmount).toFormat(2);
+        const operationIndex = i + 1;
 
         return (
           <OperationBox>
             <OperationBoxHeader>
-              Operation <strong>{operationTypes[type]}</strong>
+              Operation {operationIndex} <strong>{operationTypes[type]}</strong>
             </OperationBoxHeader>
             <ListEl>
               {amount ? (
@@ -218,7 +227,6 @@ export const SignTransaction = () => {
       <BackButton onClick={() => window.location.replace("/")} />
       <Header>Confirm Transaction</Header>
       <Subheader>{title} is requesting a transaction</Subheader>
-      {/* <Subheader>Transaction details</Subheader> */}
       <ListEl>
         <li>
           <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,11 @@ bignumber.js@^4.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
Ticket: [UI - Preview and sign a transaction](https://app.asana.com/0/1168666457741233/1168291088234574)

- Added `bignumber.js` library
- I had to `yarn build` in order to have the new styles applied even though I had no changes to `background` and `content script`. I wonder if it's because although this page is located in `/popup`, it can only viewed through `playground`. I am going to look at it why in more depth tomorrow morning.

Preview:
![signintransaction-screenshot](https://user-images.githubusercontent.com/3912060/85760147-90b58980-b6df-11ea-8b9b-ac7127e1fb98.jpg)
