### PR TITLE
bugfix/pop-windowsize > increasing popup window size to avoid scroll

### DIFF
--- a/src/background/messageListener/lyraApiMessageListener.ts
+++ b/src/background/messageListener/lyraApiMessageListener.ts
@@ -8,7 +8,7 @@ import { responseQueue, transactionQueue } from "./popupMessageListener";
 import { store, publicKeySelector } from "../ducks/session";
 
 const WHITELIST_ID = "whitelist";
-const WINDOW_DIMENSIONS = "height=600,width=357";
+const WINDOW_DIMENSIONS = "width=456,height=667";
 
 export const lyraApiMessageListener = (
   request: Request,


### PR DESCRIPTION
Ticket: [Popup windows have scroll and show the menu](https://app.asana.com/0/1168666457741233/1181841301138284)
- Increased its popup window's `width` and `height`
- Only `px` is allowed so we cannot completely avoid scrolling for cases like "Confirm Transaction" that might have many operations than its max height

Preview:
**Welcome Page**
<img width="470" alt="after-fix-welcome" src="https://user-images.githubusercontent.com/3912060/86148102-342fe100-bac8-11ea-8c28-239d737d4741.png">

**Connection Request**
<img width="470" alt="after-fix-connection-request" src="https://user-images.githubusercontent.com/3912060/86148105-35610e00-bac8-11ea-89e1-73fc1299350c.png">

**FYI - Transaction page should have a scroll since it could have many operations**
<img width="456" alt="after-fix-confirm-transaction" src="https://user-images.githubusercontent.com/3912060/86148099-33974a80-bac8-11ea-845f-668c7ef1ea91.png">
