### PR TITLE
bugfix/fullscreen > do not display <Header/> while Loading...

### DIFF
--- a/src/popup/components/Layout/Header/index.tsx
+++ b/src/popup/components/Layout/Header/index.tsx
@@ -1,5 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+import { useSelector } from "react-redux";
+
+import { APPLICATION_STATE } from "statics";
+
+import { applicationStateSelector } from "popup/ducks/authServices";
 
 import { COLOR_PALETTE } from "popup/styles";
 
@@ -33,9 +38,17 @@ type HeaderProps = {
   className?: string;
 };
 
-export const Header = ({ className, ...props }: HeaderProps) => (
-  <HeaderEl className={className} {...props}>
-    <HeaderH1>Lyra</HeaderH1>
-    <NetworkEl>Test net</NetworkEl>
-  </HeaderEl>
-);
+export const Header = ({ className, ...props }: HeaderProps) => {
+  const applicationState = useSelector(applicationStateSelector);
+
+  if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
+    return null;
+  }
+
+  return (
+    <HeaderEl className={className} {...props}>
+      <HeaderH1>Lyra</HeaderH1>
+      <NetworkEl>Test net</NetworkEl>
+    </HeaderEl>
+  );
+};


### PR DESCRIPTION
Ticket : [Fix <FullscreenStyle> implementation](https://app.asana.com/0/1168666457741233/1180179289017515)
- <FullscreenStyle> (the global style that makes Onboarding full screen) implements itself only after `loadAccount` figures out what stage the user is in. This creates a flash of "small screen" style before it fixes itself.

- I made it so that `<Header/>` won't be displayed while `Loading..`. However, I wonder if we are going to have design for `Loading...` for a small and large screen?