### PR TITLE
bugfix/fullscreen > do not display <Header/> while <Loading/> and <Loading/> to be a full width component

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -19,6 +19,7 @@ const GlobalStyle = createGlobalStyle`
     font-family: 'Muli', sans-serif;
     font-size: 100%;
     margin: 0;
+    padding:0;
   }
 
   body, html {
@@ -26,6 +27,10 @@ const GlobalStyle = createGlobalStyle`
   }
   body, html, #root {
     height: 100vh;
+  }
+
+  body * {
+    box-sizing: border-box;
   }
 
   a {

--- a/src/popup/Router.tsx
+++ b/src/popup/Router.tsx
@@ -27,8 +27,7 @@ import RecoverAccount from "popup/views/RecoverAccount";
 import { SignTransaction } from "popup/views/SignTransaction";
 import { UnlockAccount } from "popup/views/UnlockAccount";
 import Welcome from "popup/views/Welcome";
-
-const Loading = () => <p> Loading...</p>;
+import { Loading } from "popup/views/Loading";
 
 const PublicKeyRoute = (props: RouteProps) => {
   const location = useLocation();

--- a/src/popup/components/Layout/Header/index.tsx
+++ b/src/popup/components/Layout/Header/index.tsx
@@ -1,5 +1,10 @@
 import React from "react";
 import styled from "styled-components";
+import { useSelector } from "react-redux";
+
+import { APPLICATION_STATE } from "statics";
+
+import { applicationStateSelector } from "popup/ducks/authServices";
 
 import { COLOR_PALETTE } from "popup/styles";
 
@@ -33,9 +38,17 @@ type HeaderProps = {
   className?: string;
 };
 
-export const Header = ({ className, ...props }: HeaderProps) => (
-  <HeaderEl className={className} {...props}>
-    <HeaderH1>Lyra</HeaderH1>
-    <NetworkEl>Test net</NetworkEl>
-  </HeaderEl>
-);
+export const Header = ({ className, ...props }: HeaderProps) => {
+  const applicationState = useSelector(applicationStateSelector);
+
+  if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
+    return null;
+  }
+
+  return (
+    <HeaderEl className={className} {...props}>
+      <HeaderH1>Lyra</HeaderH1>
+      <NetworkEl>Test net</NetworkEl>
+    </HeaderEl>
+  );
+};

--- a/src/popup/views/Loading/index.tsx
+++ b/src/popup/views/Loading/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import styled from "styled-components";
+
+import { FullscreenStyle } from "popup/components/Layout/Fullscreen/basics/FullscreenStyle";
+
+const LoadingEl = styled.div`
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Loading = () => (
+  <LoadingEl>
+    <FullscreenStyle />
+    <p>Loading...</p>
+  </LoadingEl>
+);


### PR DESCRIPTION
Ticket: [Fix `<FullscreenStyle>` implementation](https://app.asana.com/0/1168666457741233/1180179289017515)
- `<Header/>` to not display while `APPLICATION_STATE. APPLICATION_LOADING `
- Created a component `<Loading/>` assuming we will have design for it. Full width with centered content
- Also added `box-sizing: border-box` for `body * {}`. Otherwise, I had to add it for each page component