### PR TITLE
Onboarding > Updated to match the design comp

### DIFF
--- a/src/popup/Router.tsx
+++ b/src/popup/Router.tsx
@@ -19,14 +19,14 @@ import { newTabHref } from "helpers";
 import { POPUP_WIDTH } from "popup/constants";
 
 import { Account } from "popup/views/Account";
-import CreatePassword from "popup/views/CreatePassword";
+import { CreatePassword } from "popup/views/CreatePassword";
 import { GrantAccess } from "popup/views/GrantAccess";
-import MnemonicPhrase from "popup/views/MnemonicPhrase";
-import MnemonicPhraseConfirmed from "popup/views/MnemonicPhrase/Confirmed";
-import RecoverAccount from "popup/views/RecoverAccount";
+import { MnemonicPhrase } from "popup/views/MnemonicPhrase";
+import { MnemonicPhraseConfirmed } from "popup/views/MnemonicPhrase/Confirmed";
+import { RecoverAccount } from "popup/views/RecoverAccount";
 import { SignTransaction } from "popup/views/SignTransaction";
 import { UnlockAccount } from "popup/views/UnlockAccount";
-import Welcome from "popup/views/Welcome";
+import { Welcome } from "popup/views/Welcome";
 import { Loading } from "popup/views/Loading";
 
 const PublicKeyRoute = (props: RouteProps) => {

--- a/src/popup/basics/index.tsx
+++ b/src/popup/basics/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { ErrorMessage, Field } from "formik";
 
+import { HEADER_HEIGHT } from "popup/constants";
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/styles";
 
 import ChevronIcon from "popup/assets/icon-chevron.svg";
@@ -54,6 +55,9 @@ interface BackButtonProps {
 }
 
 const BackButtonEl = styled(BasicButton)`
+  position: absolute;
+  top: calc(${HEADER_HEIGHT}px + 1rem);
+  left: 1rem;
   display: flex;
   align-items: center;
   background: ${COLOR_PALETTE.inputBackground};
@@ -86,6 +90,7 @@ export const FormErrorEl = styled.div`
   height: 1rem;
   padding: 0.25rem 0 0.75rem;
   text-align: center;
+  line-height: 1;
 `;
 
 const FormCheckBoxWrapper = styled.div`
@@ -181,6 +186,23 @@ export const FormTextField = styled(Field)`
   font-size: 1rem;
   padding: 1.875rem 2.25rem;
   width: 100%;
+  resize: none;
+
+  &::-webkit-input-placeholder {
+    font-family: "Muli", sans-serif;
+  }
+
+  &:-ms-input-placeholder {
+    font-family: "Muli", sans-serif;
+  }
+
+  &:-moz-placeholder {
+    font-family: "Muli", sans-serif;
+  }
+
+  &::-moz-placeholder {
+    font-family: "Muli", sans-serif;
+  }
 `;
 
 export const FormCheckboxField = ({ name }: { name: string }) => (

--- a/src/popup/components/Form/index.tsx
+++ b/src/popup/components/Form/index.tsx
@@ -4,6 +4,7 @@ import { Form as FormikForm } from "formik";
 
 interface FormProps {
   children: React.ReactNode;
+  className?: string;
 }
 
 const StyledForm = styled(FormikForm)`
@@ -11,6 +12,8 @@ const StyledForm = styled(FormikForm)`
   flex-flow: column wrap;
 `;
 
-const Form = ({ children }: FormProps) => <StyledForm>{children}</StyledForm>;
+const Form = ({ children, className }: FormProps) => (
+  <StyledForm className={className}>{children}</StyledForm>
+);
 
 export default Form;

--- a/src/popup/components/Layout/Fullscreen/Onboarding.tsx
+++ b/src/popup/components/Layout/Fullscreen/Onboarding.tsx
@@ -1,36 +1,66 @@
 import React from "react";
 import styled from "styled-components";
+
+import { HEADER_HEIGHT } from "popup/constants";
 import { COLOR_PALETTE } from "popup/styles";
+
 import { BackButton } from "popup/basics";
 import { FullscreenStyle } from "./basics";
 
-const HeaderEl = styled.h1`
+interface HeaderProps {
+  isMaxHeaderLength?: boolean;
+}
+
+const HeaderEl = styled.h1<HeaderProps>`
   color: ${COLOR_PALETTE.primary};
   font-weight: 200;
   font-size: 2.5rem;
-  line-height: 3.4rem;
-  margin: 0;
-  max-width: 21rem;
+  line-height: 1.3;
+  margin: 0.625rem 0;
+  max-width: ${(props) => (props.isMaxHeaderLength ? "22.35rem" : "21rem")};
 `;
 
 const SubheaderEl = styled.h2`
   color: ${COLOR_PALETTE.secondaryText};
   font-weight: 400;
   font-size: 0.9rem;
-  max-width: 21rem;
+  max-width: 23rem;
 `;
 
 export const Screen = styled.section`
-  align-content: center;
   display: flex;
   flex-flow: column wrap;
+  align-content: center;
   justify-content: center;
-  padding: 100px 170px;
-  height: 40rem;
+  height: calc(100vh - ${HEADER_HEIGHT}px);
+  max-height: 40rem;
+  max-width: 57rem;
+  width: 100%;
+  margin: auto;
+
+  & > * {
+    display: flex;
+    flex-direction: column;
+    flex: 0 1 21.25rem;
+    justify-content: center;
+  }
+
+  /* Fix this in /basics once using the formik hook */
+  textarea {
+    margin-top: 2rem;
+    min-height: 10rem;
+  }
 `;
 
 export const HalfScreen = styled.section`
-  padding: 0 1.6rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0;
+  padding-top: 3.25rem;
+  padding-right: 0;
+  padding-bottom: 2rem;
+  padding-left: 4.55rem;
   width: 27rem;
 `;
 
@@ -38,16 +68,20 @@ const EmojiSpan = styled.span`
   font-size: 3.625rem;
 `;
 
+const HeadingEl = styled.div``;
+
 export const Onboarding = ({
   goBack,
   header,
   subheader,
   icon: { emoji, alt },
   children,
+  isMaxHeaderLength,
 }: {
   goBack?: () => void;
   header: string;
   subheader?: string;
+  isMaxHeaderLength?: boolean;
   icon: { emoji: string; alt: string };
   children: React.ReactNode;
 }) => (
@@ -55,11 +89,13 @@ export const Onboarding = ({
     <FullscreenStyle />
     {goBack ? <BackButton onClick={goBack} /> : null}
     <Screen>
-      <EmojiSpan role="img" aria-label={alt}>
-        {emoji}
-      </EmojiSpan>
-      <HeaderEl>{header}</HeaderEl>
-      {subheader ? <SubheaderEl>{subheader}</SubheaderEl> : null}
+      <HeadingEl>
+        <EmojiSpan role="img" aria-label={alt}>
+          {emoji}
+        </EmojiSpan>
+        <HeaderEl isMaxHeaderLength={isMaxHeaderLength}>{header}</HeaderEl>
+        {subheader ? <SubheaderEl>{subheader}</SubheaderEl> : null}
+      </HeadingEl>
       {children}
     </Screen>
   </>

--- a/src/popup/components/Layout/Header/index.tsx
+++ b/src/popup/components/Layout/Header/index.tsx
@@ -6,6 +6,7 @@ import { APPLICATION_STATE } from "statics";
 
 import { applicationStateSelector } from "popup/ducks/authServices";
 
+import { HEADER_HEIGHT } from "popup/constants";
 import { COLOR_PALETTE } from "popup/styles";
 
 const HeaderEl = styled.header`
@@ -16,6 +17,7 @@ const HeaderEl = styled.header`
   align-items: center;
   padding: 2.25rem 2rem;
   text-align: left;
+  height: ${HEADER_HEIGHT}px;
 `;
 
 const HeaderH1 = styled.h1`

--- a/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
@@ -15,10 +15,13 @@ import {
   FormRow,
   FormSubmitButton,
 } from "popup/basics";
-import CheckButton from "./basics/CheckButton";
+
+import CloseIcon from "popup/assets/icon-close.svg";
+
+import { CheckButton } from "./basics/CheckButton";
 
 const ConfirmInput = styled.div`
-  background: #d2d8e5;
+  background: ${COLOR_PALETTE.inputBackground};
   border: 0;
   border-radius: 1.875rem;
   box-sizing: border-box;
@@ -39,11 +42,23 @@ const ClearButton = styled(ButtonEl)`
   margin: 0 0 0 0.5rem;
   padding: 0;
   width: 1.5rem;
+
+  img {
+    width: 0.5rem;
+  }
 `;
 
-const WordBubbleWrapper = styled(HalfScreen)`
+const WordBubbleWrapper = styled.div`
   display: flex;
   flex-flow: wrap;
+  justify-content: flex-start;
+  padding-bottom: 3rem;
+`;
+
+const ModifiedHalfScreen = styled(HalfScreen)`
+  padding: 0;
+  padding-left: 5rem;
+  width: 31rem;
 `;
 
 const convertToWord = (wordKey: string) => wordKey.replace(/-.*/, "");
@@ -113,21 +128,19 @@ const ConfirmMnemonicPhrase = ({ words = [""] }: { words: string[] }) => {
       <Formik initialValues={initialWordState} onSubmit={handleSubmit}>
         {({ setValues, values, isSubmitting, handleChange }) => (
           <Form>
-            <>
-              <HalfScreen>
-                <ConfirmInput>
-                  {displaySelectedWords()}
-                  {selectedWords.length ? (
-                    <ClearButton
-                      type="button"
-                      onClick={() => removeLastWord(values, setValues)}
-                    >
-                      X
-                    </ClearButton>
-                  ) : null}
-                </ConfirmInput>
-                <ApiErrorMessage error={authError}></ApiErrorMessage>
-              </HalfScreen>
+            <ModifiedHalfScreen>
+              <ConfirmInput>
+                {displaySelectedWords()}
+                {selectedWords.length ? (
+                  <ClearButton
+                    type="button"
+                    onClick={() => removeLastWord(values, setValues)}
+                  >
+                    <img src={CloseIcon} alt="clear icon" />
+                  </ClearButton>
+                ) : null}
+              </ConfirmInput>
+              <ApiErrorMessage error={authError}></ApiErrorMessage>
               <WordBubbleWrapper>{wordBubbles(handleChange)}</WordBubbleWrapper>
               <FormRow>
                 <FormSubmitButton
@@ -136,7 +149,7 @@ const ConfirmMnemonicPhrase = ({ words = [""] }: { words: string[] }) => {
                   isValid={!!displaySelectedWords().length}
                 />
               </FormRow>
-            </>
+            </ModifiedHalfScreen>
           </Form>
         )}
       </Formik>

--- a/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
+++ b/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
@@ -19,9 +19,8 @@ const MnemonicDisplay = styled.div`
   color: ${({ isBlurred }: { isBlurred: boolean }) =>
     isBlurred ? "transparent" : "#fff"};
   font-size: 1.125rem;
-  line-height: 1.8rem;
-  margin: 3.5rem 0 1rem;
-  padding: 27px 37px;
+  margin: 2rem 0 1rem;
+  padding: 1.68rem 2.31rem;
   position: relative;
   text-align: center;
   text-shadow: ${({ isBlurred }: { isBlurred: boolean }) =>
@@ -29,7 +28,7 @@ const MnemonicDisplay = styled.div`
 `;
 
 const DisplayTooltip = styled(BasicButton)`
-  color: #fff;
+  color: ${COLOR_PALETTE.white};
   font-size: 1rem;
   position: absolute;
   text-shadow: none;
@@ -39,6 +38,7 @@ const DisplayTooltip = styled(BasicButton)`
 `;
 
 const DisplayButtons = styled.div`
+  margin-bottom: 2.5rem;
   margin-right: 1rem;
   position: relative;
   text-align: right;
@@ -85,7 +85,6 @@ const DisplayMnemonicPhrase = ({
             Show backup phrase
           </DisplayTooltip>
         ) : null}
-
         {mnemonicPhrase}
       </MnemonicDisplay>
       <DisplayButtons>

--- a/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
+++ b/src/popup/components/mnemonicPhrase/basics/ActionButton.tsx
@@ -6,7 +6,7 @@ const ActionButton = styled(BasicButton)`
   color: ${COLOR_PALETTE.secondaryText};
   font-size: 0.875rem;
   font-weight: 500;
-  line-height: 1.7rem;
+  line-height: 2;
   opacity: 0.6;
 `;
 

--- a/src/popup/components/mnemonicPhrase/basics/CheckButton.tsx
+++ b/src/popup/components/mnemonicPhrase/basics/CheckButton.tsx
@@ -15,8 +15,9 @@ const ButtonLabel = styled.label`
   cursor: pointer;
   display: inline-block;
   font-weight: 800;
-  margin: 10px 5px;
-  padding: 0.75rem 1.7rem;
+  font-size: 0.75rem;
+  margin: 3px;
+  padding: 0.7rem 1.75rem;
 `;
 
 const CheckBox = styled(Field)`
@@ -28,7 +29,7 @@ const CheckBox = styled(Field)`
   }
 `;
 
-const CheckButton = ({ onChange, wordKey, word }: CheckButtonProps) => (
+export const CheckButton = ({ onChange, wordKey, word }: CheckButtonProps) => (
   <>
     <CheckBox
       id={wordKey}
@@ -41,5 +42,3 @@ const CheckButton = ({ onChange, wordKey, word }: CheckButtonProps) => (
     <ButtonLabel htmlFor={wordKey}>{word}</ButtonLabel>
   </>
 );
-
-export default CheckButton;

--- a/src/popup/constants/index.ts
+++ b/src/popup/constants/index.ts
@@ -1,5 +1,7 @@
 export const POPUP_WIDTH = 456;
 
+export const HEADER_HEIGHT = 120;
+
 export const EMOJI = {
   spy: {
     emoji: "🕵",

--- a/src/popup/views/CreatePassword/index.tsx
+++ b/src/popup/views/CreatePassword/index.tsx
@@ -68,6 +68,7 @@ export const CreatePassword = () => {
       header="Create a password"
       subheader="Min 10 characters"
       icon={EMOJI.see_no_evil}
+      goBack={() => history.push({ pathname: "/" })}
     >
       <Formik
         initialValues={initialValues}

--- a/src/popup/views/CreatePassword/index.tsx
+++ b/src/popup/views/CreatePassword/index.tsx
@@ -1,10 +1,16 @@
 import React, { useEffect } from "react";
+import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
 import { object as YupObject } from "yup";
+
 import { history } from "popup/App";
 import { createAccount, publicKeySelector } from "popup/ducks/authServices";
-import { Onboarding } from "popup/components/Layout/Fullscreen/Onboarding";
+
+import {
+  Onboarding,
+  HalfScreen,
+} from "popup/components/Layout/Fullscreen/Onboarding";
 import Form from "popup/components/Form";
 import {
   FormError,
@@ -21,7 +27,11 @@ import {
 } from "popup/components/Form/validators";
 import { EMOJI } from "popup/constants";
 
-const CreatePassword = () => {
+const ModifiedHalfScreen = styled(HalfScreen)`
+  padding-left: 1.55rem;
+`;
+
+export const CreatePassword = () => {
   const publicKey = useSelector(publicKeySelector);
   const dispatch = useDispatch();
 
@@ -58,7 +68,6 @@ const CreatePassword = () => {
       header="Create a password"
       subheader="Min 10 characters"
       icon={EMOJI.see_no_evil}
-      goBack={() => history.push({ pathname: "/" })}
     >
       <Formik
         initialValues={initialValues}
@@ -67,7 +76,7 @@ const CreatePassword = () => {
       >
         {({ isSubmitting, isValid }) => (
           <Form>
-            <>
+            <ModifiedHalfScreen>
               <FormRow>
                 <FormTextField
                   autoComplete="off"
@@ -100,12 +109,10 @@ const CreatePassword = () => {
                   isValid={isValid}
                 />
               </FormRow>
-            </>
+            </ModifiedHalfScreen>
           </Form>
         )}
       </Formik>
     </Onboarding>
   );
 };
-
-export default CreatePassword;

--- a/src/popup/views/MnemonicPhrase/Confirmed/index.tsx
+++ b/src/popup/views/MnemonicPhrase/Confirmed/index.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import styled from "styled-components";
+
 import { COLOR_PALETTE } from "popup/styles";
+import { HEADER_HEIGHT } from "popup/constants";
+
 import { FormButton } from "popup/basics";
 import { FullscreenStyle } from "popup/components/Layout/Fullscreen/basics";
 
@@ -13,15 +16,25 @@ const HeaderEl = styled.h1`
 
 const Wrapper = styled.div`
   background: ${COLOR_PALETTE.primary};
-  color: #fff;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: calc(100vh - ${HEADER_HEIGHT}px);
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 2rem 0;
   text-align: center;
+  margin: auto;
+  color: ${COLOR_PALETTE.white};
+  max-width: 24.375rem;
+  height: calc(100vh - ${HEADER_HEIGHT}px);
 `;
 
 const FinishButton = styled(FormButton)`
-  background: #654cf7;
+  background: ${COLOR_PALETTE.secondary};
   margin: 2.5rem auto 0;
 `;
 
@@ -29,10 +42,10 @@ const Celebration = styled.h1`
   font-size: 5rem;
 `;
 
-const MnemonicPhraseConfirmed = () => (
-  <>
+export const MnemonicPhraseConfirmed = () => (
+  <Wrapper>
     <FullscreenStyle />
-    <Wrapper>
+    <ContentWrapper>
       <HeaderEl>Woo, you’re in!</HeaderEl>
       <Celebration>
         <span role="img" aria-label="Celebration face">
@@ -53,8 +66,6 @@ const MnemonicPhraseConfirmed = () => (
       >
         All done
       </FinishButton>
-    </Wrapper>
-  </>
+    </ContentWrapper>
+  </Wrapper>
 );
-
-export default MnemonicPhraseConfirmed;

--- a/src/popup/views/MnemonicPhrase/index.tsx
+++ b/src/popup/views/MnemonicPhrase/index.tsx
@@ -10,7 +10,7 @@ import { Onboarding } from "popup/components/Layout/Fullscreen/Onboarding";
 import ConfirmMnemonicPhrase from "popup/components/mnemonicPhrase/ConfirmMnemonicPhrase";
 import DisplayMnemonicPhrase from "popup/components/mnemonicPhrase/DisplayMnemonicPhrase";
 
-const MnemonicPhrase = () => {
+export const MnemonicPhrase = () => {
   const [readyToConfirm, setReadyToConfirm] = useState(false);
 
   const mnemonicPhrase = useMnemonicPhrase();
@@ -36,5 +36,3 @@ const MnemonicPhrase = () => {
 
   return null;
 };
-
-export default MnemonicPhrase;

--- a/src/popup/views/RecoverAccount/index.tsx
+++ b/src/popup/views/RecoverAccount/index.tsx
@@ -107,7 +107,7 @@ export const RecoverAccount = () => {
                   placeholder="Enter your 12 word phrase to restore your wallet"
                   onChange={handleChange}
                 />
-                {/* <FormError name="mnemonicPhrase" /> */}
+                <FormError name="mnemonicPhrase" />
                 <ApiErrorMessage error={authError}></ApiErrorMessage>
               </FormRow>
               <HalfScreen>

--- a/src/popup/views/RecoverAccount/index.tsx
+++ b/src/popup/views/RecoverAccount/index.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
+import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
 import { object as YupObject, string as YupString } from "yup";
-import { history } from "popup/App";
+
 import {
   password as passwordValidator,
   confirmPassword as confirmPasswordValidator,
@@ -13,7 +14,9 @@ import {
   publicKeySelector,
   recoverAccount,
 } from "popup/ducks/authServices";
-import Form from "popup/components/Form";
+
+import { HEADER_HEIGHT } from "popup/constants";
+
 import {
   ApiErrorMessage,
   FormError,
@@ -23,12 +26,23 @@ import {
   FormSubmitButton,
   FormTextField,
 } from "popup/basics";
+import Form from "popup/components/Form";
 import {
   Onboarding,
   HalfScreen,
 } from "popup/components/Layout/Fullscreen/Onboarding";
 
-const RecoverAccount = () => {
+const FullHeightForm = styled(Form)`
+  height: calc(100vh - ${HEADER_HEIGHT}px);
+
+  section {
+    & > * {
+      flex: 0 1 6.25rem;
+    }
+  }
+`;
+
+export const RecoverAccount = () => {
   const publicKey = useSelector(publicKeySelector);
   const authError = useSelector(authErrorSelector);
 
@@ -78,20 +92,21 @@ const RecoverAccount = () => {
       validationSchema={RecoverAccountSchema}
     >
       {({ handleChange, isSubmitting, isValid }) => (
-        <Form>
+        <FullHeightForm>
           <Onboarding
             header="Recover wallet from backup phrase"
             icon={icon}
-            goBack={() => history.push({ pathname: "/" })}
+            isMaxHeaderLength
           >
             <>
               <FormRow>
                 <FormTextField
                   as="textarea"
                   name="mnemonicPhrase"
+                  placeholder="Enter your 12 word phrase to restore your wallet"
                   onChange={handleChange}
                 />
-                <FormError name="mnemonicPhrase" />
+                {/* <FormError name="mnemonicPhrase" /> */}
                 <ApiErrorMessage error={authError}></ApiErrorMessage>
               </FormRow>
               <HalfScreen>
@@ -130,10 +145,8 @@ const RecoverAccount = () => {
               </HalfScreen>
             </>
           </Onboarding>
-        </Form>
+        </FullHeightForm>
       )}
     </Formik>
   );
 };
-
-export default RecoverAccount;

--- a/src/popup/views/RecoverAccount/index.tsx
+++ b/src/popup/views/RecoverAccount/index.tsx
@@ -97,6 +97,7 @@ export const RecoverAccount = () => {
             header="Recover wallet from backup phrase"
             icon={icon}
             isMaxHeaderLength
+            goBack={() => history.push({ pathname: "/" })}
           >
             <>
               <FormRow>

--- a/src/popup/views/Welcome/index.tsx
+++ b/src/popup/views/Welcome/index.tsx
@@ -1,23 +1,23 @@
 import React from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import {
-  HalfScreen,
-  Screen,
-} from "popup/components/Layout/Fullscreen/Onboarding";
+
+import { HEADER_HEIGHT } from "popup/constants";
+
 import { FullscreenStyle } from "popup/components/Layout/Fullscreen/basics";
 import { COLOR_PALETTE } from "popup/styles";
 
 const Box = styled.div`
-  border-radius: 1.875rem;
-  color: #fff;
-  padding: 2.6rem 2.3rem;
   position: relative;
+  width: 22.75rem;
+  padding: 2.2rem 2.3rem;
+  border-radius: 1.875rem;
+  color: ${COLOR_PALETTE.white};
 `;
 
 const CreateBox = styled(Box)`
   background: ${COLOR_PALETTE.primaryGradient};
-  color: #fff;
+  color: ${COLOR_PALETTE.white};
 `;
 
 const ImportBox = styled(Box)`
@@ -29,9 +29,8 @@ const BoxHeader = styled.div`
   color: ${COLOR_PALETTE.text};
   font-size: 2.4rem;
   font-weight: 200;
-  height: 7.5rem;
-  line-height: 3.75rem;
-  margin-bottom: 2.9rem;
+  line-height: 1.5;
+  margin-bottom: 2.5rem;
 
   strong {
     color: ${COLOR_PALETTE.primary};
@@ -58,7 +57,7 @@ const LinkButtonWrapper = styled.div`
 
 const LinkButton = styled(Link)`
   border-radius: 1rem;
-  color: #fff;
+  color: ${COLOR_PALETTE.white};
   display: inline-block;
   font-weight: 800;
   margin: 3.4rem auto 0;
@@ -75,45 +74,69 @@ const ImportButton = styled(LinkButton)`
   background: ${COLOR_PALETTE.primaryGradient};
 `;
 
-const Welcome = () => (
+const ColumnScreen = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-content: center;
+  justify-content: center;
+  max-width: 49rem;
+  height: calc(100vh - ${HEADER_HEIGHT}px);
+  width: 100%;
+  margin: auto;
+`;
+
+const RowScreen = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+const HalfScreen = styled.section`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0;
+`;
+
+export const Welcome = () => (
   <>
     <FullscreenStyle />
-    <Screen>
-      <HalfScreen>
+    <ColumnScreen>
+      <RowScreen>
         <BoxHeader>
           Welcome, <br />
           are you new to <strong>Lyra?</strong>
         </BoxHeader>
-        <CreateBox>
-          <BoxIcon>
-            <span role="img" aria-label="Waving hand">
-              👋
-            </span>
-          </BoxIcon>
-          <BoxHeaderEl>I’m new!</BoxHeaderEl>
-          <p>I’m going to need a seed phrase</p>
-          <LinkButtonWrapper>
-            <CreateButton to="/create-password">Create wallet</CreateButton>
-          </LinkButtonWrapper>
-        </CreateBox>
-      </HalfScreen>
-      <HalfScreen>
-        <BoxHeader />
-        <ImportBox>
-          <BoxIcon>
-            <span role="img" aria-label="Seedling">
-              🌱
-            </span>
-          </BoxIcon>
-          <BoxHeaderEl>I’ve done this before</BoxHeaderEl>
-          <p>I have my 12 word seed phrase</p>
-          <LinkButtonWrapper>
-            <ImportButton to="/recover-account">Import wallet</ImportButton>
-          </LinkButtonWrapper>
-        </ImportBox>
-      </HalfScreen>
-    </Screen>
+      </RowScreen>
+      <RowScreen>
+        <HalfScreen>
+          <CreateBox>
+            <BoxIcon>
+              <span role="img" aria-label="Waving hand">
+                👋
+              </span>
+            </BoxIcon>
+            <BoxHeaderEl>I’m new!</BoxHeaderEl>
+            <p>I’m going to need a seed phrase</p>
+            <LinkButtonWrapper>
+              <CreateButton to="/create-password">Create wallet</CreateButton>
+            </LinkButtonWrapper>
+          </CreateBox>
+        </HalfScreen>
+        <HalfScreen>
+          <ImportBox>
+            <BoxIcon>
+              <span role="img" aria-label="Seedling">
+                🌱
+              </span>
+            </BoxIcon>
+            <BoxHeaderEl>I’ve done this before</BoxHeaderEl>
+            <p>I have my 12 word seed phrase</p>
+            <LinkButtonWrapper>
+              <ImportButton to="/recover-account">Import wallet</ImportButton>
+            </LinkButtonWrapper>
+          </ImportBox>
+        </HalfScreen>
+      </RowScreen>
+    </ColumnScreen>
   </>
 );
-
-export default Welcome;


### PR DESCRIPTION
Ticket: [On recover from phrase, if the user resizes the textarea the layout breaks](https://app.asana.com/0/1168666457741233/1181709640492800)
- Onboarding component is being used for all of Onboarding pages. Updating this was affecting all other Onboarding pages so I decided to fix its UI for all Onboarding pages. This fixes some of backlog tickets, [this](https://app.asana.com/0/1168666457741233/1181709640492781) and [this](https://app.asana.com/0/1168666457741233/1181709640492787)
- I also updated so that they would look good on bigger monitors

**Recover Account**
Before:
<img width="500" alt="original-recover" src="https://user-images.githubusercontent.com/3912060/87203817-66fc8500-c2d1-11ea-8337-2a69fd9408f4.png">

After:
<img width="500" alt="updated-recover" src="https://user-images.githubusercontent.com/3912060/87203819-66fc8500-c2d1-11ea-9540-fcff331316fb.png">

**Welcome Page**
Before: 
<img width="500" alt="original-welcome" src="https://user-images.githubusercontent.com/3912060/87203875-8abfcb00-c2d1-11ea-804b-4b9bf5b4966b.png">

After: 
<img width="500" alt="updated-welcome" src="https://user-images.githubusercontent.com/3912060/87203873-8a273480-c2d1-11ea-925d-9471a93c3d2a.png">

**Create Password**
Before: 
<img width="500" alt="original-create-password" src="https://user-images.githubusercontent.com/3912060/87203894-990de700-c2d1-11ea-8824-21baa95daedd.png">

After: 
<img width="500" alt="updated-create-password" src="https://user-images.githubusercontent.com/3912060/87203895-99a67d80-c2d1-11ea-89e9-7639f7815157.png">

**Display Mnemonic**
Before: 
<img width="500" alt="original-display-mnemonic" src="https://user-images.githubusercontent.com/3912060/87203917-a7f49980-c2d1-11ea-9bfe-d2f5bbe727a4.png">

After: 
<img width="500" alt="updated-display-mnemonic" src="https://user-images.githubusercontent.com/3912060/87203915-a75c0300-c2d1-11ea-8b61-e26d24a92875.png">

**Confirm Mnemonic**
Before: 
<img width="500" alt="original-confirm-mnemonic" src="https://user-images.githubusercontent.com/3912060/87203952-b80c7900-c2d1-11ea-85d1-8bcdabc3a470.png">

After: 
<img width="500" alt="updated-confirm-mnemonic" src="https://user-images.githubusercontent.com/3912060/87203951-b773e280-c2d1-11ea-875b-71b46e56e07a.png">

**Woo You're In**
Before: 
<img width="500" alt="original-confirmed-mnemonic" src="https://user-images.githubusercontent.com/3912060/87204014-d2deed80-c2d1-11ea-98dc-4e5ced3ccb23.png">

After: 
<img width="500" alt="updated-confirmed-mnemonic" src="https://user-images.githubusercontent.com/3912060/87204011-d2deed80-c2d1-11ea-9f8b-10ab6faad249.png">