### PR TITLE
/recover-account > Use 'component' props instead of 'as'; update its error message

### DIFF
--- a/src/popup/components/Form/validators/index.tsx
+++ b/src/popup/components/Form/validators/index.tsx
@@ -12,3 +12,5 @@ export const confirmPassword = YupString()
   .required("Password confirmation is required");
 
 export const termsOfUse = YupBool().oneOf([true], "Terms of Use are required");
+
+export const mnemonicPhrase = YupString().required("Backup phrase is required");

--- a/src/popup/views/RecoverAccount/index.tsx
+++ b/src/popup/views/RecoverAccount/index.tsx
@@ -2,12 +2,13 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
-import { object as YupObject, string as YupString } from "yup";
+import { object as YupObject } from "yup";
 
 import {
   password as passwordValidator,
   confirmPassword as confirmPasswordValidator,
   termsOfUse as termsofUseValidator,
+  mnemonicPhrase as mnemonicPhraseValidator,
 } from "popup/components/Form/validators";
 import {
   authErrorSelector,
@@ -61,7 +62,7 @@ export const RecoverAccount = () => {
   };
 
   const RecoverAccountSchema = YupObject().shape({
-    mnemonicPhrase: YupString().required(),
+    mnemonicPhrase: mnemonicPhraseValidator,
     password: passwordValidator,
     confirmPassword: confirmPasswordValidator,
     termsOfUse: termsofUseValidator,
@@ -102,10 +103,10 @@ export const RecoverAccount = () => {
             <>
               <FormRow>
                 <FormTextField
-                  as="textarea"
+                  onChange={handleChange}
+                  component="textarea"
                   name="mnemonicPhrase"
                   placeholder="Enter your 12 word phrase to restore your wallet"
-                  onChange={handleChange}
                 />
                 <FormError name="mnemonicPhrase" />
                 <ApiErrorMessage error={authError}></ApiErrorMessage>

--- a/src/popup/views/RecoverAccount/index.tsx
+++ b/src/popup/views/RecoverAccount/index.tsx
@@ -92,7 +92,7 @@ export const RecoverAccount = () => {
       onSubmit={handleSubmit}
       validationSchema={RecoverAccountSchema}
     >
-      {({ handleChange, isSubmitting, isValid }) => (
+      {({ isSubmitting, isValid }) => (
         <FullHeightForm>
           <Onboarding
             header="Recover wallet from backup phrase"
@@ -103,7 +103,6 @@ export const RecoverAccount = () => {
             <>
               <FormRow>
                 <FormTextField
-                  onChange={handleChange}
                   component="textarea"
                   name="mnemonicPhrase"
                   placeholder="Enter your 12 word phrase to restore your wallet"


### PR DESCRIPTION
Tickets:
[Use "backup phrase"on error message](https://app.asana.com/0/1168666457741233/1181709640492806)
- Updating the error message was straightforward. I moved `mnemonicPhrase `validation logic to `Form/validators/index.tsx`.

[If the user types an incorrect phrase, the Continue button changes to Loading and can't be clicked even if the phrase is correct](https://app.asana.com/0/1168666457741233/1181709640492812)
- I noticed that unlike other input fields, `textarea` wasn't throwing an error when users `onBlur` the input without any input. Adding `textarea` to `component={}` instead of `as={}` fixed this. For `component={}`,  `custom React components will be passed **FieldProps** which is same render prop parameters of <Field render> plus any other props passed to directly to <Field>` where as `as={}` is limited to passing `onChange`, `onBlur`, `name`, and `value`.
- [Formik's `Field` API Documentation](https://formik.org/docs/api/field#as)