### PR TITLE
bugfix/txfailed-message > lyra to return horizon error message

### DIFF
--- a/src/background/messageListener/popupMessageListener.ts
+++ b/src/background/messageListener/popupMessageListener.ts
@@ -223,6 +223,7 @@ export const popupMessageListener = (
 
   const signTransaction = async () => {
     const privateKey = privateKeySelector(store.getState());
+
     if (privateKey.length) {
       const sourceKeys = StellarSdk.Keypair.fromSecret(privateKey);
 
@@ -235,12 +236,13 @@ export const popupMessageListener = (
           transactionToSign.sign(sourceKeys);
           response = await server.submitTransaction(transactionToSign);
         } catch (e) {
-          response = e;
-          console.error(e);
+          response = e.response ? e.response.data : e;
+          console.error(response);
         }
       }
 
       const transactionResponse = responseQueue.pop();
+
       if (typeof transactionResponse === "function") {
         transactionResponse(response);
         sendResponse({});


### PR DESCRIPTION
Ticket: [Transaction failed should return Horizon error message](https://app.asana.com/0/1168666457741233/1182844823111073)

Related laboratory ticket is [this](https://github.com/stellar/laboratory/pull/473) with screenshots. [`Sign with Lyra` button won't display anymore](https://github.com/stellar/laboratory/pull/471) if there's an error within `transactionBuild.`.