### PR TITLE
bugfix/no-back-acct-recovery > if its a new window tab, hide the back button

### DIFF
--- a/src/popup/components/Onboarding.tsx
+++ b/src/popup/components/Onboarding.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { useHistory } from "react-router-dom";
 
 import { HEADER_HEIGHT } from "constants/dimensions";
 import { COLOR_PALETTE } from "popup/constants/styles";
@@ -84,19 +85,24 @@ export const Onboarding = ({
   isMaxHeaderLength?: boolean;
   icon: { emoji: string; alt: string };
   children: React.ReactNode;
-}) => (
-  <>
-    <FullscreenStyle />
-    {goBack ? <BackButton onClick={goBack} /> : null}
-    <Screen>
-      <HeadingEl>
-        <EmojiSpanEl role="img" aria-label={alt}>
-          {emoji}
-        </EmojiSpanEl>
-        <HeaderEl isMaxHeaderLength={isMaxHeaderLength}>{header}</HeaderEl>
-        {subheader ? <SubheaderEl>{subheader}</SubheaderEl> : null}
-      </HeadingEl>
-      {children}
-    </Screen>
-  </>
-);
+}) => {
+  const history = useHistory();
+  const isNewTabSession = history.length === 1;
+
+  return (
+    <>
+      <FullscreenStyle />
+      {goBack && !isNewTabSession ? <BackButton onClick={goBack} /> : null}
+      <Screen>
+        <HeadingEl>
+          <EmojiSpanEl role="img" aria-label={alt}>
+            {emoji}
+          </EmojiSpanEl>
+          <HeaderEl isMaxHeaderLength={isMaxHeaderLength}>{header}</HeaderEl>
+          {subheader ? <SubheaderEl>{subheader}</SubheaderEl> : null}
+        </HeadingEl>
+        {children}
+      </Screen>
+    </>
+  );
+};


### PR DESCRIPTION
Ticket: [If the user clicks on "Import user account seed phrase" and goes to the account recovery screen, there shouldn't be a back button](https://app.asana.com/0/1168666457741233/1185261482198393)

Hiding `goBack` button when onboarding itself is in a new tab. Using react router's useHistory (based on window.history) to detect [whether it's a page loaded in a new tab](https://developer.mozilla.org/en-US/docs/Web/API/History/length).
- I added in `<Onboarding/>` instead of just `Recover Account` that the ticket requested because the [line](https://github.com/stellar/lyra/blob/master/src/popup/Router.tsx#L111) for `mnemonic-phrase` is opening in a new tab as well