### PR TITLE
Field to use error props instead of hasError

### DIFF
--- a/src/popup/basics/Forms.tsx
+++ b/src/popup/basics/Forms.tsx
@@ -89,8 +89,7 @@ export const Error = ({ name }: { name: string }) => (
 
 export const TextField = styled(Field)`
   border-radius: 1.25rem;
-  border: ${(props) =>
-    props.hasError ? `1px solid ${COLOR_PALETTE.error}` : 0};
+  border: ${(props) => (props.error ? `1px solid ${COLOR_PALETTE.error}` : 0)};
   box-sizing: border-box;
   background: ${COLOR_PALETTE.inputBackground};
   font-size: 1rem;

--- a/src/popup/views/UnlockAccount.tsx
+++ b/src/popup/views/UnlockAccount.tsx
@@ -54,7 +54,7 @@ const UnorderedListEl = styled.ul`
   padding-top: 0.25rem;
 `;
 const CustomFormTextFieldEl = styled(TextField)`
-  padding-right: ${(props) => (props.hasError ? "6rem" : "2.2rem")};
+  padding-right: ${(props) => (props.error ? "6rem" : "2.2rem")};
 `;
 const ListItemEl = styled.li`
   color: ${COLOR_PALETTE.secondaryText};
@@ -117,7 +117,7 @@ export const UnlockAccount = () => {
                 type="password"
                 name="password"
                 placeholder="Enter password"
-                hasError={authError}
+                error={authError}
               />
               {authError ? (
                 <ErrorEmojiEl>


### PR DESCRIPTION
Ticket: [Add a red border to input field w error](https://app.asana.com/0/1168666457741233/1183566926171242)

I noticed that there is `error` props from [FieldMetaProps](https://github.com/formium/formik/blob/master/packages/formik/src/types.tsx#L270) for `<Field/>` on formik. Changing it from `hasError` to `error` fixed the error `React does not recognize the `hasError` prop on a DOM element.`.