### PR TITLE
Make checkboxes tab-focusable

### DIFF
--- a/src/popup/basics/Forms.tsx
+++ b/src/popup/basics/Forms.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Form as FormikForm, ErrorMessage, Field } from "formik";
 
@@ -25,7 +25,8 @@ const FormButtonEl = styled(Button)`
   }
 `;
 
-interface SubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface SubmitButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   isSubmitting?: boolean;
   isValid?: boolean;
@@ -66,11 +67,6 @@ const FormErrorEl = styled.div`
   line-height: 1;
 `;
 
-const FormCheckBoxWrapperEl = styled.div`
-  display: inline-block;
-  margin-right: 0.625rem;
-`;
-
 export const ApiErrorMessage = ({ error }: ErrorMessageProps) =>
   error ? <FormErrorEl>{error}</FormErrorEl> : null;
 
@@ -86,6 +82,11 @@ export const Error = ({ name }: { name: string }) => (
     <ErrorMessage name={name} component="span" />
   </FormErrorEl>
 );
+
+export const Label = styled.label`
+  color: ${COLOR_PALETTE.secondaryText};
+  font-size: 0.8125rem;
+`;
 
 export const TextField = styled(Field)`
   border-radius: 1.25rem;
@@ -114,44 +115,50 @@ export const TextField = styled(Field)`
   }
 `;
 
-const FormCheckboxFieldLabelEl = styled.label`
+const CheckBoxWrapperEl = styled(Label)`
+  display: flex;
+  align-items: center;
+`;
+
+const CheckboxFieldEl = styled(Field).attrs(() => ({ type: "checkbox" }))`
+  position: relative;
+  margin-right: 0.625rem;
+  appearance: unset;
   align-items: center;
   background: ${COLOR_PALETTE.inputBackground};
   border: 0.125rem solid ${COLOR_PALETTE.inputBackground};
   border-radius: 0.625rem;
   color: ${COLOR_PALETTE.primary};
   cursor: pointer;
-  display: flex;
   height: 2rem;
-  justify-content: space-evenly;
   width: 2rem;
 
-  div {
+  &:checked:after {
+    content: "";
+    background: ${COLOR_PALETTE.primary};
     border-radius: 2rem;
+    position: absolute;
+    top: 0;
+    left: 0;
     height: 1rem;
     width: 1rem;
+    margin: 0.375rem;
   }
 `;
 
-const FormCheckboxFieldEl = styled(Field)`
-  display: none;
-  &:checked + ${FormCheckboxFieldLabelEl} {
-    div {
-      background: ${COLOR_PALETTE.primary};
-    }
-  }
-`;
+interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: React.ReactNode;
+}
 
-export const CheckboxField = ({ name }: { name: string }) => (
-  <FormCheckBoxWrapperEl>
-    <FormCheckboxFieldEl id={name} name={name} type="checkbox" />
-    <FormCheckboxFieldLabelEl htmlFor={name}>
-      <div />
-    </FormCheckboxFieldLabelEl>
-  </FormCheckBoxWrapperEl>
+export const CheckboxField = ({
+  name,
+  label,
+  children,
+  className,
+  ...props
+}: CheckboxProps) => (
+  <CheckBoxWrapperEl className={className}>
+    <CheckboxFieldEl {...props} id={name} name={name} />
+    {label}
+  </CheckBoxWrapperEl>
 );
-
-export const Label = styled.label`
-  color: ${COLOR_PALETTE.secondaryText};
-  font-size: 0.8125rem;
-`;

--- a/src/popup/views/CreatePassword.tsx
+++ b/src/popup/views/CreatePassword.tsx
@@ -14,7 +14,6 @@ import {
   Error,
   FormRow,
   CheckboxField,
-  Label,
   TextField,
 } from "popup/basics/Forms";
 import {
@@ -94,10 +93,14 @@ export const CreatePassword = () => {
                 <Error name="confirmPassword" />
               </FormRow>
               <FormRow>
-                <CheckboxField name="termsOfUse" />
-                <Label htmlFor="termsOfUse">
-                  I have read and agree to <a href="/ac">Terms of Use</a>
-                </Label>
+                <CheckboxField
+                  name="termsOfUse"
+                  label={
+                    <span>
+                      I have read and agree to <a href="/ac">Terms of Use</a>
+                    </span>
+                  }
+                />
                 <Error name="termsOfUse" />
               </FormRow>
               <FormRow>

--- a/src/popup/views/RecoverAccount.tsx
+++ b/src/popup/views/RecoverAccount.tsx
@@ -24,7 +24,6 @@ import {
   Error,
   FormRow,
   CheckboxField,
-  Label,
   TextField,
   SubmitButton,
   Form,
@@ -128,10 +127,14 @@ export const RecoverAccount = () => {
                   <Error name="confirmPassword" />
                 </FormRow>
                 <FormRow>
-                  <CheckboxField name="termsOfUse" />
-                  <Label htmlFor="termsOfUse">
-                    I have read and agree to <a href="/ac">Terms of Use</a>
-                  </Label>
+                  <CheckboxField
+                    label={
+                      <span>
+                        I have read and agree to <a href="/ac">Terms of Use</a>
+                      </span>
+                    }
+                    name="termsOfUse"
+                  />
                   <Error name="termsOfUse" />
                 </FormRow>
                 <FormRow>


### PR DESCRIPTION
I had to shuffle some fo the positioning styles (and I also ended up changing the label to be a prop, instead of a sibling), but it centers a little more precisely now.
Before:
<img width="325" alt="Screen Shot 2020-07-24 at 5 10 26 PM" src="https://user-images.githubusercontent.com/1551487/88437747-232b7480-cdd5-11ea-8932-5c84d4796d6f.png">
After:
<img width="329" alt="Screen Shot 2020-07-24 at 5 21 22 PM" src="https://user-images.githubusercontent.com/1551487/88437748-23c40b00-cdd5-11ea-9e29-a2ce0d0493ba.png">
