### PR TITLE
Fix emitted route metrics

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -96,7 +96,7 @@ const HomeRoute = () => {
   }
   if (!publicKey) {
     if (applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) {
-      return <UnlockAccount />;
+      return <Redirect to={ROUTES.unlockAccount} />;
     }
 
     /*
@@ -104,14 +104,14 @@ const HomeRoute = () => {
     In this particular case, open the tab if we are in the "popup" view.
     */
     if (window.innerWidth === POPUP_WIDTH) {
-      window.open(newTabHref(ROUTES.home));
+      window.open(newTabHref(ROUTES.welcome));
     }
     return <Welcome />;
   }
 
   switch (applicationState) {
     case APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED:
-      return <Account />;
+      return <Redirect to={ROUTES.account} />;
     case APPLICATION_STATE.PASSWORD_CREATED ||
       APPLICATION_STATE.MNEMONIC_PHRASE_FAILED:
       window.open(newTabHref(ROUTES.mnemonicPhrase));

--- a/extension/src/popup/constants/metricsNames.ts
+++ b/extension/src/popup/constants/metricsNames.ts
@@ -1,5 +1,5 @@
 export const METRIC_NAMES = {
-  viewHome: "loaded page: home",
+  viewWelcome: "loaded page: welcome",
   viewAccount: "loaded page: account",
   viewCreatePassword: "loaded page: create password",
   viewGrantAccess: "loaded page: grant access",
@@ -9,7 +9,6 @@ export const METRIC_NAMES = {
   viewRecoverAccount: "loaded page: recover account",
   viewSignTransaction: "loaded page: sign transaction",
   viewUnlockAccount: "loaded page: unlock account",
-  viewWelcome: "loaded page: welcome",
 
   newWallet: "new wallet: create password: success",
   confirmPassword: "re-auth: success",

--- a/extension/src/popup/constants/routes.ts
+++ b/extension/src/popup/constants/routes.ts
@@ -1,5 +1,5 @@
 export const ROUTES = {
-  home: "/",
+  welcome: "/",
   account: "/account",
   signTransaction: "/sign-transaction",
   grantAccess: "/grant-access",

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -7,7 +7,7 @@ import { AppState } from "popup/App";
 import { ROUTES } from "popup/constants/routes";
 
 const routeToEventName = {
-  [ROUTES.home]: METRIC_NAMES.viewHome,
+  [ROUTES.welcome]: METRIC_NAMES.viewWelcome,
   [ROUTES.account]: METRIC_NAMES.viewAccount,
   [ROUTES.signTransaction]: METRIC_NAMES.viewSignTransaction,
   [ROUTES.grantAccess]: METRIC_NAMES.viewGrantAccess,


### PR DESCRIPTION
I realized that the /account and /unlock-account pages wouldn't fire route metrics correctly on page load, since they're done as conditional rendering on `/`. This changes them to be shown via redirects.