### PR TITLE
Add project-wide build/start commands

### DIFF
--- a/@shared/api/package.json
+++ b/@shared/api/package.json
@@ -2,6 +2,7 @@
   "name": "@shared/api",
   "prettier": "@stellar/prettier-config",
   "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "prettier": "^2.0.5",
     "stellar-sdk": "5.0.1",

--- a/@shared/constants/config.js
+++ b/@shared/constants/config.js
@@ -1,0 +1,20 @@
+const DEFAULT_STATS = {
+  // minimal
+  // can use `preset: "minimal"` once webpack 5 lands
+  all: false,
+  modules: true,
+  maxModules: 0,
+  errors: true,
+  warnings: true,
+  // our additional options
+  moduleTrace: true,
+  errorDetails: true,
+  assets: true,
+  excludeAssets: [/\.d\.ts/, /\.png/, /\.jpe?g/],
+  hash: true,
+  timings: true,
+};
+
+module.exports = {
+  DEFAULT_STATS,
+};

--- a/@shared/constants/config.js
+++ b/@shared/constants/config.js
@@ -6,7 +6,8 @@ const DEFAULT_STATS = {
   maxModules: 0,
   errors: true,
   warnings: true,
-  // our additional options
+  // We want to keep output narrowly focused when possible because there's a lot
+  // of different watchers started at once.
   moduleTrace: true,
   errorDetails: true,
   assets: true,

--- a/@stellar/lyra-api/package.json
+++ b/@stellar/lyra-api/package.json
@@ -11,7 +11,8 @@
   "main": "build/index.min.js",
   "scripts": {
     "prepare": "yarn build",
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack --config webpack.config.js --watch"
   },
   "types": "build/@stellar/lyra-api/src/index.d.ts",
   "prettier": "@stellar/prettier-config",

--- a/@stellar/lyra-api/package.json
+++ b/@stellar/lyra-api/package.json
@@ -11,8 +11,8 @@
   "main": "build/index.min.js",
   "scripts": {
     "prepare": "yarn build",
-    "build": "webpack --config webpack.config.js",
-    "start": "webpack --config webpack.config.js --watch"
+    "build": "webpack --config webpack.config.js --mode production",
+    "start": "webpack --config webpack.config.js --watch --mode development"
   },
   "types": "build/@stellar/lyra-api/src/index.d.ts",
   "prettier": "@stellar/prettier-config",

--- a/@stellar/lyra-api/package.json
+++ b/@stellar/lyra-api/package.json
@@ -1,15 +1,20 @@
 {
   "name": "@stellar/lyra-api",
-  "main": "build/index.min.js",
-  "types": "build/@stellar/lyra-api/src/index.d.ts",
-  "prettier": "@stellar/prettier-config",
   "version": "1.0.0-alpha.2",
+  "license": "Apache-2.0",
+  "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Lyra extension",
   "repository": {
     "url": "git@github.com:stellar/lyra.git",
     "type": "git"
   },
-  "author": "Stellar Development Foundation <hello@stellar.org>",
+  "main": "build/index.min.js",
+  "scripts": {
+    "prepare": "yarn build",
+    "build": "webpack --config webpack.config.js"
+  },
+  "types": "build/@stellar/lyra-api/src/index.d.ts",
+  "prettier": "@stellar/prettier-config",
   "browserslist": {
     "production": [
       "last 3 chrome version",
@@ -20,7 +25,6 @@
       "last 1 firefox version"
     ]
   },
-  "license": "MIT",
   "lint-staged": {
     "src/**/*.ts?(x)": [
       "eslint --fix --max-warnings 0"
@@ -41,9 +45,5 @@
     "typescript": "~3.7.2",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12"
-  },
-  "scripts": {
-    "prepare": "yarn build",
-    "build": "webpack --config webpack.config.js"
   }
 }

--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -40,6 +40,20 @@ const config = {
       DEVELOPMENT: false,
     }),
   ],
+  stats: {
+    // minimal
+    // can use `preset: "minimal"` once webpack 5 lands
+    all: false,
+    modules: true,
+    maxModules: 0,
+    errors: true,
+    warnings: true,
+    // our additional options
+    moduleTrace: true,
+    errorDetails: true,
+    hash: true,
+    timings: true,
+  },
 };
 
 module.exports = config;

--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -40,8 +40,6 @@ const config = {
       DEVELOPMENT: false,
     }),
   ],
-  // This module is super simple, so we don't need much information about what
-  // build. Turn most of it off to keep output focused.
   stats: DEFAULT_STATS,
 };
 

--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -6,7 +6,6 @@ const { DEFAULT_STATS } = require("../../@shared/constants/config");
 const BUILD_PATH = path.resolve(__dirname, "./build");
 
 const config = {
-  mode: "production",
   entry: {
     index: path.resolve(__dirname, "./src/index.ts"),
   },

--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -40,6 +40,8 @@ const config = {
       DEVELOPMENT: false,
     }),
   ],
+  // This module is super simple, so we don't need much information about what
+  // build. Turn most of it off to keep output focused.
   stats: {
     // minimal
     // can use `preset: "minimal"` once webpack 5 lands

--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require("webpack");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const path = require("path");
+const { DEFAULT_STATS } = require("../../@shared/constants/config");
 
 const BUILD_PATH = path.resolve(__dirname, "./build");
 
@@ -42,20 +43,7 @@ const config = {
   ],
   // This module is super simple, so we don't need much information about what
   // build. Turn most of it off to keep output focused.
-  stats: {
-    // minimal
-    // can use `preset: "minimal"` once webpack 5 lands
-    all: false,
-    modules: true,
-    maxModules: 0,
-    errors: true,
-    warnings: true,
-    // our additional options
-    moduleTrace: true,
-    errorDetails: true,
-    hash: true,
-    timings: true,
-  },
+  stats: DEFAULT_STATS,
 };
 
 module.exports = config;

--- a/README.md
+++ b/README.md
@@ -9,8 +9,53 @@ This repo is constructed using yarn workspaces and consists of the 4 sections:
 
 ## Getting Started
 
-From the project root, run `yarn install`. This will install all shared node modules in the root while each workspace will get a `node_modules` folder consisting of only the packages specific to that workspace.
+```
+yarn
+yarn start
+```
+
+This will start up multiple watching builds in parallel:
+
+- The `@stellar/lyra-api` npm module
+- The docs, serving on `localhost:3000`
+- A dev server with the webapp running in the extension, serving on
+  `localhost:9000`
+- The actual built extension, able to be installed in Chrome, in `build/`
+
+Each of these will build in response to editing their source.
+
+These can be started individually with `yarn start:\<workspace name\>` where
+`\<workspace name\>` is one of:
+
+- `lyra-api`
+- `docs`
+- `extension`
+
+```
+yarn build
+```
+
+This will produce final output for the docs, the `@stellar/lyra` npm module, and
+the extension.
+
+`yarn build:\<workspace name\>`, like the equivalent start commands, will build
+an individual workspace.
+
+### Useful URLs:
+
+[The popup webapp](http://localhost:9000/#/)
+
+[The `getPublicKey` playground](http://localhost:3000/docs/playground/getPublicKey)
+[The `signTransaction` playground](http://localhost:3000/docs/playground/signTransaction)
+
+It's important to note that these two won't interact with the _dev server_ popup
+UI on `localhost:9000` — you'll need to re-install the unpacked extension each
+time you make a change.
 
 ## Importing a workspace
 
-In some cases, you will want to import a workspace into another. For example, in `extension` we need to import `@lyra/constants`. To do this, simply add `@lyra/constants` to the dependencies list in package.json in `extension`. Yarn symlinks all the workspaces, so doing so will allow you to import files from the `@lyra/constants` workspace as if it were a published npm package.
+In some cases, you will want to import a workspace into another. For example, in
+`extension` we need to import `@lyra/constants`. To do this, simply add
+`@lyra/constants` to the dependencies list in package.json in `extension`. Yarn
+symlinks all the workspaces, so doing so will allow you to import files from the
+`@lyra/constants` workspace as if it were a published npm package.

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0-alpha",
   "private": true,
   "scripts": {
-    "buildDependencies": "yarn workspace @stellar/lyra-api build",
     "docusaurus": "docusaurus",
-    "start": "yarn buildDependencies && docusaurus start",
+    "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,17 +11,6 @@
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve"
   },
-  "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.61",
-    "@docusaurus/preset-classic": "^2.0.0-alpha.60",
-    "@mdx-js/react": "^1.5.8",
-    "@stellar/lyra-api": "1.0.0-alpha.2",
-    "clsx": "^1.1.1",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
-    "react-is": "^16.13.1",
-    "styled-components": "^5.0.1"
-  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -33,5 +22,16 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "dependencies": {
+    "@docusaurus/core": "^2.0.0-alpha.61",
+    "@docusaurus/preset-classic": "^2.0.0-alpha.60",
+    "@mdx-js/react": "^1.5.8",
+    "@stellar/lyra-api": "1.0.0-alpha.2",
+    "clsx": "^1.1.1",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4",
+    "react-is": "^16.13.1",
+    "styled-components": "^5.0.1"
   }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -12,7 +12,8 @@
   "husky": {
     "hooks": {
       "pre-commit": "concurrently 'pretty-quick --staged' 'lint-staged'",
-      "post-merge": "yarn install-if-package-changed"
+      "post-merge": "yarn install-if-package-changed",
+      "post-checkout": "yarn install-if-package-changed"
     }
   },
   "lint-staged": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "extension",
+  "version": "1.0.0-alpha.6",
   "license": "Apache-2.0",
   "prettier": "@stellar/prettier-config",
-  "version": "1.0.0-alpha.6",
   "scripts": {
     "install-if-package-changed": "git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep --quiet yarn.lock && yarn install || exit 0",
     "build": "webpack --config webpack.prod.js",

--- a/extension/package.json
+++ b/extension/package.json
@@ -4,82 +4,15 @@
   "license": "Apache-2.0",
   "prettier": "@stellar/prettier-config",
   "scripts": {
-    "install-if-package-changed": "git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep --quiet yarn.lock && yarn install || exit 0",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack-dev-server --config webpack.dev.js",
     "start:unpacked-extension": "yarn build --watch",
     "test": "jest"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "concurrently 'pretty-quick --staged' 'lint-staged'",
-      "post-merge": "yarn install-if-package-changed",
-      "post-checkout": "yarn install-if-package-changed"
-    }
-  },
-  "lint-staged": {
-    "src/**/*.ts?(x)": [
-      "eslint --fix --max-warnings 0"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      "last 3 chrome version",
-      "last 3 firefox version"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version"
-    ]
-  },
   "babel": {
-    "presets": [
-      "@babel/preset-typescript",
-      "@babel/preset-react",
-      [
-        "@babel/preset-env",
-        {
-          "targets": {
-            "node": "current"
-          }
-        }
-      ]
-    ]
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx,mjs}"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setupTests.ts"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/config/jest/extendJest.ts"
-    ],
-    "testEnvironment": "node",
-    "testURL": "http://localhost",
-    "transform": {
-      "^.+\\.(js|jsx|ts|tsx|mjs)$": [
-        "babel-jest"
-      ]
-    },
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
-    },
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "json",
-      "node",
-      "mjs",
-      "ts",
-      "tsx"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "<rootDir>/src",
-      "<rootDir>/.."
+    "babelRcRoots": [
+      ".",
+      ".."
     ]
   },
   "dependencies": {
@@ -138,13 +71,11 @@
     "history": "^4",
     "html-loader": "^1.0.0",
     "html-webpack-plugin": "^4.0.1",
-    "husky": "^4.2.3",
     "isomorphic-unfetch": "^3.0.0",
     "jest": "^26.3.0",
     "jest-localstorage-mock": "^2.4.3",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
-    "lint-staged": "^10.0.7",
     "lodash": "^4.17.15",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -7,6 +7,7 @@
     "install-if-package-changed": "git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep --quiet yarn.lock && yarn install || exit 0",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack-dev-server --config webpack.dev.js",
+    "start:unpacked-extension": "yarn build --watch",
     "test": "jest"
   },
   "husky": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "start": "webpack-dev-server --config webpack.dev.js",
-    "start:unpacked-extension": "yarn build --watch",
+    "start:unpacked-extension": "yarn build --watch --info-verbosity verbose",
     "test": "jest"
   },
   "babel": {

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -3,24 +3,9 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const path = require("path");
 
-const BUILD_PATH = path.resolve(__dirname, "./build");
+const { DEFAULT_STATS } = require("../@shared/constants/config");
 
-// Fine tune output to reduce noise. The project-wide start command is noisy
-// already, so this aggressively tunes output to only what's necessary.
-const statsSettings = {
-  // minimal
-  // can use `preset: "minimal"` once webpack 5 lands
-  all: false,
-  modules: true,
-  maxModules: 0,
-  errors: true,
-  warnings: true,
-  // our additional options
-  moduleTrace: true,
-  errorDetails: true,
-  hash: true,
-  timings: true,
-};
+const BUILD_PATH = path.resolve(__dirname, "./build");
 
 const commonConfig = {
   node: { global: true, fs: "empty" },
@@ -87,12 +72,9 @@ const commonConfig = {
       filename: `${BUILD_PATH}/index.html`,
     }),
   ],
-  stats: statsSettings,
+  stats: DEFAULT_STATS,
   devServer: {
-    stats: {
-      ...statsSettings,
-      assets: true,
-    },
+    stats: DEFAULT_STATS,
   },
 };
 

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -5,6 +5,23 @@ const path = require("path");
 
 const BUILD_PATH = path.resolve(__dirname, "./build");
 
+// Fine tune output to reduce noise. The project-wide start command is noisy
+// already, so this aggressively tunes output to only what's necessary.
+const statsSettings = {
+  // minimal
+  // can use `preset: "minimal"` once webpack 5 lands
+  all: false,
+  modules: true,
+  maxModules: 0,
+  errors: true,
+  warnings: true,
+  // our additional options
+  moduleTrace: true,
+  errorDetails: true,
+  hash: true,
+  timings: true,
+};
+
 const commonConfig = {
   node: { global: true, fs: "empty" },
   entry: {
@@ -70,35 +87,11 @@ const commonConfig = {
       filename: `${BUILD_PATH}/index.html`,
     }),
   ],
-  stats: {
-    // minimal
-    // can use `preset: "minimal"` once webpack 5 lands
-    all: false,
-    modules: true,
-    maxModules: 0,
-    errors: true,
-    warnings: true,
-    // our additional options
-    moduleTrace: true,
-    errorDetails: true,
-    hash: true,
-    timings: true,
-  },
+  stats: statsSettings,
   devServer: {
     stats: {
-      // minimal
-      // can use `preset: "minimal"` once webpack 5 lands
-      all: false,
-      modules: true,
-      maxModules: 0,
-      errors: true,
-      warnings: true,
-      // our additional options
-      moduleTrace: true,
-      errorDetails: true,
+      ...statsSettings,
       assets: true,
-      hash: true,
-      timings: true,
     },
   },
 };

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -17,6 +17,9 @@ const commonConfig = {
     index: ["babel-polyfill", path.resolve(__dirname, "./src/popup/index.tsx")],
     contentScript: path.resolve(__dirname, "./public/contentScript.ts"),
   },
+  watchOptions: {
+    ignored: ["node_modules/**/*", "build/**/*"],
+  },
   output: {
     path: BUILD_PATH,
     filename: "[name].min.js",

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -70,6 +70,37 @@ const commonConfig = {
       filename: `${BUILD_PATH}/index.html`,
     }),
   ],
+  stats: {
+    // minimal
+    // can use `preset: "minimal"` once webpack 5 lands
+    all: false,
+    modules: true,
+    maxModules: 0,
+    errors: true,
+    warnings: true,
+    // our additional options
+    moduleTrace: true,
+    errorDetails: true,
+    hash: true,
+    timings: true,
+  },
+  devServer: {
+    stats: {
+      // minimal
+      // can use `preset: "minimal"` once webpack 5 lands
+      all: false,
+      modules: true,
+      maxModules: 0,
+      errors: true,
+      warnings: true,
+      // our additional options
+      moduleTrace: true,
+      errorDetails: true,
+      assets: true,
+      hash: true,
+      timings: true,
+    },
+  },
 };
 
 module.exports.commonConfig = commonConfig;

--- a/extension/webpack.prod.js
+++ b/extension/webpack.prod.js
@@ -12,6 +12,8 @@ const prodConfig = {
       DEVELOPMENT: false,
     }),
   ],
+  // This if to fine tune logged output. Since this is an extension, not a
+  // webapp, we don't really care how large the bundle is.
   performance: {
     hints: false,
   },

--- a/extension/webpack.prod.js
+++ b/extension/webpack.prod.js
@@ -12,6 +12,9 @@ const prodConfig = {
       DEVELOPMENT: false,
     }),
   ],
+  performance: {
+    hints: false,
+  },
 };
 
 module.exports = merge(prodConfig, commonConfig);

--- a/package.json
+++ b/package.json
@@ -6,5 +6,14 @@
     "docs",
     "extension",
     "@stellar/lyra-api"
-  ]
+  ],
+  "scripts": {
+    "build": "run-p --print-label build:lyra-api build:docs build:extension",
+    "build:lyra-api": "yarn workspace @stellar/lyra-api build",
+    "build:docs": "yarn workspace docs build",
+    "build:extension": "yarn workspace extension build"
+  },
+  "dependencies": {
+    "npm-run-all": "^4.1.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "build": "run-p --print-label build:lyra-api build:docs build:extension",
     "build:lyra-api": "yarn workspace @stellar/lyra-api build",
     "build:docs": "yarn workspace docs build",
-    "build:extension": "yarn workspace extension build"
+    "build:extension": "yarn workspace extension build",
+    "start": "run-p --print-label start:lyra-api start:docs start:extension",
+    "start:lyra-api": "yarn workspace @stellar/lyra-api start",
+    "start:docs": "yarn workspace docs start",
+    "start:extension": "yarn workspace extension start"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "build:lyra-api": "yarn workspace @stellar/lyra-api build",
     "build:docs": "yarn workspace docs build",
     "build:extension": "yarn workspace extension build",
-    "start": "run-p --print-label start:lyra-api start:docs start:extension",
+    "start": "run-p --print-label start:lyra-api start:docs start:extension start:unpacked",
     "start:lyra-api": "yarn workspace @stellar/lyra-api start",
     "start:docs": "yarn workspace docs start",
-    "start:extension": "yarn workspace extension start"
+    "start:extension": "yarn workspace extension start",
+    "start:unpacked": "yarn workspace extension start:unpacked-extension"
   },
   "dependencies": {
     "npm-run-all": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "build": "run-p --print-label build:lyra-api build:docs build:extension",
+    "build:netlify": "run-s build:lyra-api build:docs",
     "build:lyra-api": "yarn workspace @stellar/lyra-api build",
     "build:docs": "yarn workspace docs build",
     "build:extension": "yarn workspace extension build",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "license": "Apache-2.0",
   "private": true,
   "workspaces": [
     "@shared/api",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,84 @@
     "start:lyra-api": "yarn workspace @stellar/lyra-api start",
     "start:docs": "yarn workspace docs start",
     "start:extension": "yarn workspace extension start",
-    "start:unpacked": "yarn workspace extension start:unpacked-extension"
+    "start:unpacked": "yarn workspace extension start:unpacked-extension",
+    "install-if-package-changed": "git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | grep --quiet yarn.lock && yarn install || exit 0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "concurrently 'pretty-quick --staged' 'lint-staged'",
+      "post-merge": "yarn install-if-package-changed",
+      "post-checkout": "yarn install-if-package-changed"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.ts?(x)": [
+      "eslint --fix --max-warnings 0"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      "last 3 chrome version",
+      "last 3 firefox version"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version"
+    ]
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-typescript",
+      "@babel/preset-react",
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "node": "current"
+          }
+        }
+      ]
+    ]
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,mjs}"
+    ],
+    "setupFiles": [
+      "<rootDir>/config/jest/setupTests.ts"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/config/jest/extendJest.ts"
+    ],
+    "testEnvironment": "node",
+    "testURL": "http://localhost",
+    "transform": {
+      "^.+\\.(js|jsx|ts|tsx|mjs)$": [
+        "babel-jest"
+      ]
+    },
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "jsx",
+      "json",
+      "node",
+      "mjs",
+      "ts",
+      "tsx"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "<rootDir>/src",
+      "<rootDir>/.."
+    ]
   },
   "dependencies": {
+    "husky": "^4.2.5",
+    "lint-staged": "^10.2.11",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7182,7 +7182,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^4.2.3:
+husky@^4.2.3, husky@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.5.tgz#2b4f7622673a71579f901d9885ed448394b5fa36"
   integrity sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==
@@ -8600,7 +8600,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.0.7:
+lint-staged@^10.0.7, lint-staged@^10.2.11:
   version "10.2.11"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.11.tgz#713c80877f2dc8b609b05bc59020234e766c9720"
   integrity sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8645,6 +8645,16 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -9070,6 +9080,11 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -9538,6 +9553,21 @@ normalize-url@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -10155,6 +10185,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -11360,6 +11395,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 read-pkg@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
@@ -12198,7 +12242,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
@@ -12726,6 +12770,14 @@ string.prototype.matchall@^4.0.2:
     internal-slot "^1.0.2"
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
+
+string.prototype.padend@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
+  integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This has a couple of similar changes:

* Reorganize `package.json` files for consistency
* Use Apache 2.0 everywhere
* Add `yarn build` and `yarn start` as commands at the root of the project
  * `build` will produce production artifacts for the extension, docs, and `@stellar/lyra-api`
  * `start` runs file watchers for everything we might need to check while making changes. See the readme for more

There's still advantages to running individual components on their own, cuz if you're not touching docs then the watcher isn't helping you. I was finding that I'd forget to rebuild one part of it or another when trying to make modifications though, so this will at least make the default command a little more tolerant to user error.