### PR TITLE
Add integration test for mnemonic confirmation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ["dynamic-import-node"],
   presets: [
     "@babel/preset-typescript",
     "@babel/preset-react",
@@ -6,9 +7,9 @@ module.exports = {
       "@babel/preset-env",
       {
         targets: {
-          node: "current"
-        }
-      }
-    ]
-  ]
+          node: "current",
+        },
+      },
+    ],
+  ],
 };

--- a/extension/src/__mocks__/react-copy-to-clipboard.js
+++ b/extension/src/__mocks__/react-copy-to-clipboard.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+const CopyToClipboard = ({ onCopy, children, ...props }) => (
+  <div {...props} onClick={() => onCopy()}>
+    {children}
+  </div>
+);
+
+export default CopyToClipboard;

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -1,4 +1,3 @@
-import { createHashHistory } from "history";
 import React from "react";
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import { combineReducers } from "redux";
@@ -48,8 +47,6 @@ const store = configureStore({
   reducer: rootReducer,
   middleware: [metricsMiddleware<AppState>(), ...getDefaultMiddleware()],
 });
-
-export const history = createHashHistory();
 
 export function App() {
   return (

--- a/extension/src/popup/components/Menu.tsx
+++ b/extension/src/popup/components/Menu.tsx
@@ -12,7 +12,7 @@ import { POPUP_WIDTH } from "constants/dimensions";
 
 import { BasicButton } from "popup/basics/Buttons";
 
-import { history } from "popup/App";
+import { history } from "popup/constants/history";
 import { applicationStateSelector, signOut } from "popup/ducks/authServices";
 import { Header } from "popup/components/Header";
 

--- a/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
+++ b/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
@@ -1,15 +1,19 @@
 import React, { useState } from "react";
+import { Redirect } from "react-router-dom";
 import styled from "styled-components";
 import { Formik } from "formik";
 import { useSelector, useDispatch } from "react-redux";
 
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import {
   confirmMnemonicPhrase,
   authErrorSelector,
+  applicationStateSelector,
 } from "popup/ducks/authServices";
 
 import CloseIcon from "popup/assets/icon-close.svg";
 
+import { ROUTES } from "popup/constants/routes";
 import { COLOR_PALETTE } from "popup/constants/styles";
 import { Button } from "popup/basics/Buttons";
 import {
@@ -82,6 +86,7 @@ export const ConfirmMnemonicPhrase = ({
   );
   const [selectedWords, setSelectedWords] = useState<string[]>([]);
   const authError = useSelector(authErrorSelector);
+  const applicationState = useSelector(applicationStateSelector);
 
   const updatePhrase = (target: HTMLInputElement) => {
     if (target.checked) {
@@ -95,19 +100,6 @@ export const ConfirmMnemonicPhrase = ({
   };
 
   const wordStateArr: [string, boolean][] = Object.entries(initialWordState);
-
-  const wordBubbles = (handleChange: (e: React.FormEvent) => void) =>
-    wordStateArr.map(([wordKey]) => (
-      <CheckButton
-        key={wordKey}
-        onChange={(e) => {
-          handleChange(e);
-          updatePhrase(e.target);
-        }}
-        wordKey={wordKey}
-        word={convertToWord(wordKey)}
-      />
-    ));
 
   interface Values {
     [x: string]: boolean;
@@ -129,6 +121,10 @@ export const ConfirmMnemonicPhrase = ({
   const displaySelectedWords = () =>
     selectedWords.map((word) => convertToWord(word)).join(" ");
 
+  if (applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) {
+    return <Redirect to={ROUTES.mnemonicPhraseConfirmed} />;
+  }
+
   return (
     <>
       <Formik initialValues={initialWordState} onSubmit={handleSubmit}>
@@ -148,7 +144,17 @@ export const ConfirmMnemonicPhrase = ({
               </ConfirmInputEl>
               <ApiErrorMessage error={authError}></ApiErrorMessage>
               <WordBubbleWrapperEl>
-                {wordBubbles(handleChange)}
+                {wordStateArr.map(([wordKey]) => (
+                  <CheckButton
+                    key={wordKey}
+                    onChange={(e) => {
+                      handleChange(e);
+                      updatePhrase(e.target);
+                    }}
+                    wordKey={wordKey}
+                    word={convertToWord(wordKey)}
+                  />
+                ))}
               </WordBubbleWrapperEl>
               <FormRow>
                 <SubmitButton

--- a/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
+++ b/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase.tsx
@@ -158,6 +158,7 @@ export const ConfirmMnemonicPhrase = ({
               </WordBubbleWrapperEl>
               <FormRow>
                 <SubmitButton
+                  data-testid="confirm"
                   isSubmitting={isSubmitting}
                   isValid={!!displaySelectedWords().length}
                 >

--- a/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
+++ b/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
@@ -9,6 +9,7 @@ import { COLOR_PALETTE } from "popup/constants/styles";
 import { emitMetric } from "helpers/metrics";
 
 import { METRIC_NAMES } from "popup/constants/metricsNames";
+import { download } from "popup/helpers/download";
 import { BasicButton } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
 
@@ -69,14 +70,6 @@ export const DisplayMnemonicPhrase = ({
   const [isCopied, setIsCopied] = useState(false);
   const [isBlurred, setIsBlurred] = useState(true);
 
-  const downloadPhrase = () => {
-    const el = document.createElement("a");
-    const file = new Blob([mnemonicPhrase], { type: "text/plain" });
-    el.href = URL.createObjectURL(file);
-    el.download = "lyraMnemonicPhrase.txt";
-    document.body.appendChild(el);
-    el.click();
-  };
   return (
     <HalfScreen data-testid="display-mnemonic-phrase">
       <p>
@@ -104,7 +97,10 @@ export const DisplayMnemonicPhrase = ({
         <ActionButton
           data-testid="download"
           onClick={() => {
-            downloadPhrase();
+            download({
+              filename: "lyraMnemonicPhrase.txt",
+              content: mnemonicPhrase,
+            });
             emitMetric(METRIC_NAMES.accountCreatorMnemonicDownloadPhrase);
           }}
         >

--- a/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
+++ b/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase.tsx
@@ -78,7 +78,7 @@ export const DisplayMnemonicPhrase = ({
     el.click();
   };
   return (
-    <HalfScreen>
+    <HalfScreen data-testid="display-mnemonic-phrase">
       <p>
         Your secret backup phrase makes it easy to back up and restore your
         account.
@@ -89,6 +89,7 @@ export const DisplayMnemonicPhrase = ({
       <MnemonicDisplayEl isBlurred={isBlurred}>
         {isBlurred ? (
           <DisplayTooltipEl
+            data-testid="show"
             onClick={() => {
               setIsBlurred(false);
               emitMetric(METRIC_NAMES.accountCreatorMnemonicViewPhrase);
@@ -101,6 +102,7 @@ export const DisplayMnemonicPhrase = ({
       </MnemonicDisplayEl>
       <DisplayButtonsEl>
         <ActionButton
+          data-testid="download"
           onClick={() => {
             downloadPhrase();
             emitMetric(METRIC_NAMES.accountCreatorMnemonicDownloadPhrase);
@@ -110,6 +112,7 @@ export const DisplayMnemonicPhrase = ({
           <img src={Download} alt="Download button" />
         </ActionButton>
         <CopyToClipboard
+          data-testid="copy"
           text={mnemonicPhrase}
           onCopy={() => {
             setIsCopied(true);
@@ -130,6 +133,7 @@ export const DisplayMnemonicPhrase = ({
         </CopiedToastWrapperEl>
       </DisplayButtonsEl>
       <SubmitButton
+        data-testid="confirm"
         onClick={() => {
           setReadyToConfirm(true);
         }}

--- a/extension/src/popup/constants/history.ts
+++ b/extension/src/popup/constants/history.ts
@@ -1,0 +1,3 @@
+import { createHashHistory } from "history";
+
+export const history = createHashHistory();

--- a/extension/src/popup/ducks/authServices.ts
+++ b/extension/src/popup/ducks/authServices.ts
@@ -4,7 +4,6 @@ import {
   createSlice,
 } from "@reduxjs/toolkit";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
-import { history } from "popup/constants/history";
 import {
   confirmMnemonicPhrase as confirmMnemonicPhraseService,
   createAccount as createAccountService,
@@ -87,7 +86,10 @@ export const confirmMnemonicPhrase = createAsyncThunk<
     }
 
     if (res.isCorrectPhrase) {
-      history.push("/mnemonic-phrase-confirmed");
+      res = {
+        isCorrectPhrase: true,
+        applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+      };
     } else {
       return thunkApi.rejectWithValue({
         applicationState: res.applicationState,

--- a/extension/src/popup/ducks/authServices.ts
+++ b/extension/src/popup/ducks/authServices.ts
@@ -4,7 +4,7 @@ import {
   createSlice,
 } from "@reduxjs/toolkit";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
-import { history } from "popup/App";
+import { history } from "popup/constants/history";
 import {
   confirmMnemonicPhrase as confirmMnemonicPhraseService,
   createAccount as createAccountService,

--- a/extension/src/popup/helpers/download.ts
+++ b/extension/src/popup/helpers/download.ts
@@ -1,0 +1,14 @@
+export const download = ({
+  filename,
+  content,
+}: {
+  filename: string;
+  content: string;
+}) => {
+  const el = document.createElement("a");
+  const file = new Blob([content], { type: "text/plain" });
+  el.href = URL.createObjectURL(file);
+  el.download = filename;
+  document.body.appendChild(el);
+  el.click();
+};

--- a/extension/src/popup/views/AccountCreator.tsx
+++ b/extension/src/popup/views/AccountCreator.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
 import { object as YupObject } from "yup";
 
-import { history } from "popup/App";
+import { history } from "popup/constants/history";
 import { createAccount, publicKeySelector } from "popup/ducks/authServices";
 
 import { Onboarding, HalfScreen } from "popup/components/Onboarding";

--- a/extension/src/popup/views/RecoverAccount.tsx
+++ b/extension/src/popup/views/RecoverAccount.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
 import { object as YupObject } from "yup";
 
-import { history } from "popup/App";
+import { history } from "popup/constants/history";
 import {
   password as passwordValidator,
   confirmPassword as confirmPasswordValidator,

--- a/extension/src/popup/views/UnlockAccount.tsx
+++ b/extension/src/popup/views/UnlockAccount.tsx
@@ -20,7 +20,7 @@ import {
   TextField,
 } from "popup/basics/Forms";
 
-import { history } from "popup/App";
+import { history } from "popup/constants/history";
 import { confirmPassword, authErrorSelector } from "popup/ducks/authServices";
 
 const UnlockAccountEl = styled.div`

--- a/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
+++ b/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import {
+  render,
+  waitFor,
+  screen,
+  fireEvent,
+  act,
+} from "@testing-library/react";
+import { Provider } from "react-redux";
+
+import { reducer as auth } from "popup/ducks/authServices";
+import { ROUTES } from "popup/constants/routes";
+
+import { MnemonicPhrase } from "../MnemonicPhrase";
+
+jest.mock("popup/metrics/authServices");
+const MNEMONIC = "dummy mnemonic";
+
+const rootReducer = combineReducers({
+  auth,
+});
+const makeDummyStore = (state: any) =>
+  configureStore({
+    reducer: rootReducer,
+    preloadedState: state,
+  });
+
+const { MemoryRouter } = jest.requireActual("react-router-dom");
+const Wrapper: React.FunctionComponent<any> = ({ children, state }) => (
+  <MemoryRouter>
+    <Provider store={makeDummyStore(state)}>{children}</Provider>
+  </MemoryRouter>
+);
+jest.mock("popup/helpers/useMnemonicPhrase", () => ({
+  useMnemonicPhrase: () => "dummy mnemonic",
+}));
+jest.mock("react-router-dom", () => {
+  const ReactRouter = jest.requireActual("react-router-dom");
+  return {
+    ...ReactRouter,
+    Redirect: ({ to }: any) => <div>redirect {to}</div>,
+  };
+});
+jest.mock("@shared/api/internal", () => {
+  const { APPLICATION_STATE } = jest.requireActual(
+    "@shared/constants/applicationState",
+  );
+  return {
+    confirmMnemonicPhrase: () =>
+      Promise.resolve({
+        isCorrectPhrase: true,
+        applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+      }),
+  };
+});
+
+describe("MnemonicPhrase", () => {
+  it("renders", async () => {
+    render(
+      <Wrapper>
+        <MnemonicPhrase />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId("display-mnemonic-phrase"));
+    expect(screen.getByTestId("display-mnemonic-phrase")).toBeDefined();
+  });
+
+  describe("basic flow", () => {
+    it("works", async () => {
+      render(
+        <Wrapper state={{ auth: { error: null, applicationState: "butts" } }}>
+          <MnemonicPhrase />
+        </Wrapper>,
+      );
+      // Reveal mnemonic
+      fireEvent.click(screen.getByTestId("show"));
+      await waitFor(() => screen.getByText(MNEMONIC));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm"));
+        await waitFor(() => screen.getByText(MNEMONIC));
+        // Click each word in the mnemonic
+        MNEMONIC.split(" ").forEach((word) =>
+          fireEvent.click(screen.getByLabelText(word)),
+        );
+        fireEvent.click(screen.getByTestId("confirm"));
+      });
+      await waitFor(() =>
+        screen.getByText(`redirect ${ROUTES.mnemonicPhraseConfirmed}`),
+      );
+    });
+  });
+});


### PR DESCRIPTION
This came out quite well! By clicking buttons and asserting metrics were called and that content loads, I feel pretty confident that this works whenever the test passes, even if we swap out the implementation.

