### PR TITLE
added url in sign transaction view and added metrics for sign transaction's options

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -59,6 +59,7 @@
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
     "prop-types": "^15.7.2",
+    "punycode": "^2.1.1",
     "react": "^16.12.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.12.0",

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -1,2 +1,22 @@
 export const truncatedPublicKey = (publicKey: string) =>
   `${publicKey.slice(0, 4)}…${publicKey.slice(-4)}`;
+
+export const getTransactionInfo = (search: string) => {
+  const decodedTransactionInfo = atob(search.replace("?", ""));
+  const transactionInfo = decodedTransactionInfo
+    ? JSON.parse(decodedTransactionInfo)
+    : {};
+
+  const {
+    tab: { title, url },
+    transaction,
+  } = transactionInfo;
+
+  const u = new URL(url);
+
+  return {
+    title,
+    transaction,
+    domain: u.origin,
+  };
+};

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -13,9 +13,15 @@ export const getTransactionInfo = (search: string) => {
   } = transactionInfo;
 
   const u = new URL(url);
+  const { _operations } = transaction;
+  const operationTypes = _operations.map(
+    (operation: { type: string }) => operation.type,
+  );
 
   return {
     transaction,
     domain: u.hostname,
+    operations: _operations,
+    operationTypes,
   };
 };

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -8,15 +8,14 @@ export const getTransactionInfo = (search: string) => {
     : {};
 
   const {
-    tab: { title, url },
+    tab: { url },
     transaction,
   } = transactionInfo;
 
   const u = new URL(url);
 
   return {
-    title,
     transaction,
-    domain: u.origin,
+    domain: u.hostname,
   };
 };

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -33,7 +33,7 @@ registerHandler<AppState>(navigate, (_, a) => {
 
   // "/sign-transaction" and "/grant-access" require additionak metrics on loaded page
   if (search) {
-    const { transaction, domain } = getTransactionInfo(search);
+    const { domain } = getTransactionInfo(search);
     const METRIC_OPTION_DOMAIN = {
       domain,
     };
@@ -43,14 +43,10 @@ registerHandler<AppState>(navigate, (_, a) => {
     }
 
     if (pathname === ROUTES.signTransaction) {
-      const { _operations } = transaction;
-      const operationTypes = transaction._operations.map(
-        (operation: { type: string }) => operation.type,
-      );
-
+      const { operations, operationTypes } = getTransactionInfo(search);
       const METRIC_OPTIONS = {
         ...METRIC_OPTION_DOMAIN,
-        number_of_operations: _operations.length,
+        number_of_operations: operations.length,
         operationTypes,
       };
 

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -1,6 +1,7 @@
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 import { registerHandler, emitMetric } from "helpers/metrics";
+import { getTransactionInfo } from "helpers/stellar";
 
 import { navigate } from "popup/ducks/views";
 import { AppState } from "popup/App";
@@ -22,11 +23,40 @@ const routeToEventName = {
 registerHandler<AppState>(navigate, (_, a) => {
   // Awkward, but gives us types on action payload
   const action = a as ReturnType<typeof navigate>;
-  const { pathname } = action.payload.location;
+  const { pathname, search } = action.payload.location;
+
   const eventName = routeToEventName[pathname];
 
   if (!eventName) {
     throw new Error(`Didn't find a metric event name for path '${pathname}'`);
   }
-  emitMetric(eventName);
+
+  // "/sign-transaction" and "/grant-access" require additionak metrics on loaded page
+  if (search) {
+    const { transaction, domain } = getTransactionInfo(search);
+    const METRIC_OPTION_DOMAIN = {
+      domain,
+    };
+
+    if (pathname === ROUTES.grantAccess) {
+      emitMetric(eventName, METRIC_OPTION_DOMAIN);
+    }
+
+    if (pathname === ROUTES.signTransaction) {
+      const { _operations } = transaction;
+      const operationTypes = transaction._operations.map(
+        (operation: { type: string }) => operation.type,
+      );
+
+      const METRIC_OPTIONS = {
+        ...METRIC_OPTION_DOMAIN,
+        number_of_operations: _operations.length,
+        operationTypes,
+      };
+
+      emitMetric(eventName, METRIC_OPTIONS);
+    }
+  } else {
+    emitMetric(eventName);
+  }
 });

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -24,6 +24,7 @@ registerHandler<AppState>(navigate, (_, a) => {
   const action = a as ReturnType<typeof navigate>;
   const { pathname } = action.payload.location;
   const eventName = routeToEventName[pathname];
+
   if (!eventName) {
     throw new Error(`Didn't find a metric event name for path '${pathname}'`);
   }

--- a/extension/src/popup/views/SignTransaction.tsx
+++ b/extension/src/popup/views/SignTransaction.tsx
@@ -23,6 +23,7 @@ const HeaderEl = styled.h1`
   color: ${COLOR_PALETTE.primary}};
   font-weight: ${FONT_WEIGHT.light};
   margin: 1rem 0 0.75rem;
+  padding-top: 1.5rem;
 `;
 const SubheaderEl = styled.h3`
   font-weight: ${FONT_WEIGHT.bold};
@@ -83,7 +84,7 @@ const RejectButtonEl = styled(Button)`
 export const SignTransaction = () => {
   const location = useLocation();
   const dispatch = useDispatch();
-  const { title, transaction, domain } = getTransactionInfo(location.search);
+  const { transaction, domain } = getTransactionInfo(location.search);
 
   const { _fee, _operations } = transaction;
   const publicKey = useSelector(publicKeySelector);
@@ -223,9 +224,7 @@ export const SignTransaction = () => {
     <El>
       <BackButton onClick={() => window.location.replace("/")} />
       <HeaderEl>Confirm Transaction</HeaderEl>
-      <SubheaderEl>
-        {title} from {domain} is requesting a transaction
-      </SubheaderEl>
+      <SubheaderEl>{domain} is requesting a transaction</SubheaderEl>
       <ListEl>
         <li>
           <div>

--- a/extension/src/popup/views/SignTransaction.tsx
+++ b/extension/src/popup/views/SignTransaction.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import BigNumber from "bignumber.js";
 import styled from "styled-components";
+import BigNumber from "bignumber.js";
+import punycode from "punycode";
 
 import { truncatedPublicKey, getTransactionInfo } from "helpers/stellar";
 
@@ -85,6 +86,7 @@ export const SignTransaction = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const { transaction, domain } = getTransactionInfo(location.search);
+  const punycodedDomain = punycode.toASCII(domain);
 
   const { _fee, _operations } = transaction;
   const publicKey = useSelector(publicKeySelector);
@@ -224,7 +226,7 @@ export const SignTransaction = () => {
     <El>
       <BackButton onClick={() => window.location.replace("/")} />
       <HeaderEl>Confirm Transaction</HeaderEl>
-      <SubheaderEl>{domain} is requesting a transaction</SubheaderEl>
+      <SubheaderEl>{punycodedDomain} is requesting a transaction</SubheaderEl>
       <ListEl>
         <li>
           <div>


### PR DESCRIPTION
Ticket: [In Sign Transaction confirmation modal, show requesting site's url](https://app.asana.com/0/1168666457741233/1185789836547227)

- UI updated, following this [model](https://projects.invisionapp.com/prototype/Lyra-Lite-ck60vjr6j003ky301z14bfmta/play/781cb375). Design isn't asking for page title so I removed it.
<img width="456" alt="Screen Shot 2020-08-27 at 10 00 03 AM" src="https://user-images.githubusercontent.com/3912060/91452278-65205e00-e84c-11ea-87a3-db0aff4a2fb1.png">

- Added metrics for `loaded: sign transaction` and `loaded: grant access`.
<img width="687" alt="metric_example" src="https://user-images.githubusercontent.com/3912060/91115017-3b521600-e657-11ea-8333-9cb3acaaf29e.png">

- [Punycode](https://app.asana.com/0/1167950234569163/1168342146125315) functionality to verify the domain url added.