### PR TITLE
return response as a string and throw error if needed

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -2,10 +2,7 @@ import { EXTERNAL_SERVICE_TYPES } from "../constants/services";
 import { sendMessageToContentScript } from "./helpers";
 import { LyraApiRequest } from "./types";
 
-export const requestPublicKey = async (): Promise<{
-  publicKey: string;
-  error: string;
-}> => {
+export const requestPublicKey = async (): Promise<string> => {
   let response = { publicKey: "", error: "" };
   try {
     response = await sendMessageToContentScript({
@@ -14,15 +11,18 @@ export const requestPublicKey = async (): Promise<{
   } catch (e) {
     console.error(e);
   }
-  return response;
+
+  const { publicKey, error } = response;
+
+  if (error) {
+    throw error;
+  }
+  return publicKey;
 };
 
 export const submitTransaction = async ({
   transactionXdr,
-}: LyraApiRequest): Promise<{
-  signedTransaction: string;
-  error: string;
-}> => {
+}: LyraApiRequest): Promise<string> => {
   let response = { signedTransaction: "", error: "" };
   try {
     response = await sendMessageToContentScript({
@@ -32,5 +32,10 @@ export const submitTransaction = async ({
   } catch (e) {
     console.error(e);
   }
-  return response;
+  const { signedTransaction, error } = response;
+
+  if (error) {
+    throw error;
+  }
+  return signedTransaction;
 };

--- a/@stellar/lyra-api/src/__tests__/getPublicKey.test.js
+++ b/@stellar/lyra-api/src/__tests__/getPublicKey.test.js
@@ -1,0 +1,18 @@
+import { getPublicKey } from "../getPublicKey";
+import * as apiExternal from "@shared/api/external";
+
+describe("getPublicKey", () => {
+  it("returns a publicKey", async () => {
+    const TEST_KEY = "100";
+    apiExternal.requestPublicKey = jest.fn().mockReturnValue(TEST_KEY);
+    const publicKey = await getPublicKey();
+    expect(publicKey).toBe(TEST_KEY);
+  });
+  it("throws an error", async () => {
+    const TEST_ERROR = "Error!";
+    apiExternal.requestPublicKey = jest.fn().mockImplementation(() => {
+      throw TEST_ERROR;
+    });
+    expect(getPublicKey).toThrowError(TEST_ERROR);
+  });
+});

--- a/@stellar/lyra-api/src/__tests__/signTransaction.test.js
+++ b/@stellar/lyra-api/src/__tests__/signTransaction.test.js
@@ -1,0 +1,18 @@
+import { signTransaction } from "../signTransaction";
+import * as apiExternal from "@shared/api/external";
+
+describe("signTransaction", () => {
+  it("returns a transaction", async () => {
+    const TEST_TRANSACTION = "AAA";
+    apiExternal.submitTransaction = jest.fn().mockReturnValue(TEST_TRANSACTION);
+    const transaction = await signTransaction();
+    expect(transaction).toBe(TEST_TRANSACTION);
+  });
+  it("throws an error", async () => {
+    const TEST_ERROR = "Error!";
+    apiExternal.submitTransaction = jest.fn().mockImplementation(() => {
+      throw TEST_ERROR;
+    });
+    expect(signTransaction).toThrowError(TEST_ERROR);
+  });
+});

--- a/@stellar/lyra-api/src/getPublicKey.ts
+++ b/@stellar/lyra-api/src/getPublicKey.ts
@@ -9,5 +9,11 @@ export const getPublicKey = async () => {
     console.error(e);
   }
 
-  return response;
+  const { error } = response;
+
+  if (error) {
+    throw error;
+  }
+
+  return response.publicKey;
 };

--- a/@stellar/lyra-api/src/getPublicKey.ts
+++ b/@stellar/lyra-api/src/getPublicKey.ts
@@ -1,19 +1,3 @@
 import { requestPublicKey } from "@shared/api/external";
 
-export const getPublicKey = async () => {
-  let response = { publicKey: "", error: "" };
-
-  try {
-    response = await requestPublicKey();
-  } catch (e) {
-    console.error(e);
-  }
-
-  const { error } = response;
-
-  if (error) {
-    throw error;
-  }
-
-  return response.publicKey;
-};
+export const getPublicKey = () => requestPublicKey();

--- a/@stellar/lyra-api/src/signTransaction.ts
+++ b/@stellar/lyra-api/src/signTransaction.ts
@@ -1,20 +1,5 @@
 import { submitTransaction } from "@shared/api/external";
 import { LyraApiRequest } from "@shared/api/types";
 
-export const signTransaction = async (params: LyraApiRequest) => {
-  let response = { signedTransaction: "", error: "" };
-
-  try {
-    response = await submitTransaction(params);
-  } catch (e) {
-    console.error(e);
-  }
-
-  const { error } = response;
-
-  if (error) {
-    throw error;
-  }
-
-  return response.signedTransaction;
-};
+export const signTransaction = (params: LyraApiRequest) =>
+  submitTransaction(params);

--- a/@stellar/lyra-api/src/signTransaction.ts
+++ b/@stellar/lyra-api/src/signTransaction.ts
@@ -10,5 +10,11 @@ export const signTransaction = async (params: LyraApiRequest) => {
     console.error(e);
   }
 
-  return response;
+  const { error } = response;
+
+  if (error) {
+    throw error;
+  }
+
+  return response.signedTransaction;
 };

--- a/docs/docs/guide/usingLyra.md
+++ b/docs/docs/guide/usingLyra.md
@@ -51,18 +51,23 @@ if (isConnected()) {
 }
 
 const retrievePublicKey = async () => {
-  let res = { publicKey: "", error: "" };
+  let publicKey = "";
+  let error = "";
 
   try {
-    res = await getPublicKey();
+    publicKey = await getPublicKey();
   } catch (e) {
-    res = e;
+    error = e;
   }
 
-  return res;
+  if (error) {
+    return error;
+  }
+
+  return publicKey;
 };
 
-const { publicKey, error } = retrievePublicKey();
+const result = retrievePublicKey();
 ```
 
 ### signTransaction
@@ -83,26 +88,40 @@ if (isConnected()) {
 }
 
 const retrievePublicKey = async () => {
-  let res = { publicKey: "", error: "" };
+  let publicKey = "";
+  let error = "";
 
   try {
-    res = await getPublicKey();
+    publicKey = await getPublicKey();
   } catch (e) {
-    res = e;
+    error = e;
   }
 
-  return res;
+  if (error) {
+    return error;
+  }
+
+  return publicKey;
 };
 
+const retrievedPublicKey = retrievePublicKey();
+
 const userSignTransaction = async (xdr: String) => {
-  let res = { signedTransaction: "", error: "" };
+  let signedTransaction = "";
+  let error = "";
 
   try {
     res = await signTransaction({ transactionXdr: xdr });
   } catch (e) {
-    res = e;
+    error = e;
   }
 
-  return res;
+  if (error) {
+    return error;
+  }
+
+  return signedTransaction;
 };
+
+const userSignedTransaction = userSignTransaction();
 ```

--- a/docs/docs/playground/components/GetPublicKeyDemo.tsx
+++ b/docs/docs/playground/components/GetPublicKeyDemo.tsx
@@ -5,13 +5,13 @@ import { PlaygroundInput } from "./basics/inputs";
 export const GetPublicKeyDemo = () => {
   const [publicKeyResult, setPublicKeyResult] = useState("");
   const btnHandler = async () => {
-    let res = { publicKey: "", error: "" };
+    let publicKey;
+    let error = "";
     try {
-      res = await getPublicKey();
+      publicKey = await getPublicKey();
     } catch (e) {
-      res = e;
+      error = e;
     }
-    const { publicKey, error } = res;
     setPublicKeyResult(publicKey || error);
   };
   return (

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -9,13 +9,14 @@ export const SignTransactionDemo = () => {
     setTransactionXdr(e.currentTarget.value);
   };
   const btnHandler = async () => {
-    let res = { signedTransaction: "", error: "" };
+    let signedTransaction;
+    let error = "";
+
     try {
-      res = await signTransaction({ transactionXdr });
+      signedTransaction = await signTransaction({ transactionXdr });
     } catch (e) {
-      res = e;
+      error = e;
     }
-    const { signedTransaction, error } = res;
     setTransactionResult(signedTransaction || error);
   };
   return (


### PR DESCRIPTION
https://app.asana.com/0/1168666457741233/1188320836740117

`background` returns an object with the string you requested plus an error (if applicable)

Here, we're breaking that object down to return only what the user wants: either a string representing the data they asked for a thrown error indicating the user declined access