### PR TITLE
/grant-access to display punycode url; separated the decoded search param code

### DIFF
--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -1,4 +1,4 @@
-import { parsedSearchParam } from "./urls";
+import { parsedSearchParam, getUrlHostname } from "./urls";
 
 export const truncatedPublicKey = (publicKey: string) =>
   `${publicKey.slice(0, 4)}…${publicKey.slice(-4)}`;
@@ -10,8 +10,7 @@ export const getTransactionInfo = (search: string) => {
     tab: { url },
     transaction,
   } = transactionInfo;
-
-  const u = new URL(url);
+  const hostname = getUrlHostname(url);
   const { _operations } = transaction;
   const operationTypes = _operations.map(
     (operation: { type: string }) => operation.type,
@@ -19,7 +18,7 @@ export const getTransactionInfo = (search: string) => {
 
   return {
     transaction,
-    domain: u.hostname,
+    domain: hostname,
     operations: _operations,
     operationTypes,
   };

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -1,11 +1,10 @@
+import { parsedSearchParam } from "./urls";
+
 export const truncatedPublicKey = (publicKey: string) =>
   `${publicKey.slice(0, 4)}…${publicKey.slice(-4)}`;
 
 export const getTransactionInfo = (search: string) => {
-  const decodedTransactionInfo = atob(search.replace("?", ""));
-  const transactionInfo = decodedTransactionInfo
-    ? JSON.parse(decodedTransactionInfo)
-    : {};
+  const transactionInfo = parsedSearchParam(search);
 
   const {
     tab: { url },

--- a/extension/src/helpers/urls.ts
+++ b/extension/src/helpers/urls.ts
@@ -1,2 +1,6 @@
 export const newTabHref = (path = "") => `index.html#${path}`;
 export const removeQueryParam = (url = "") => url.replace(/\?(.*)/, "");
+export const parsedSearchParam = (param: string) => {
+  const decodedSearchParam = atob(param.replace("?", ""));
+  return decodedSearchParam ? JSON.parse(decodedSearchParam) : {};
+};

--- a/extension/src/helpers/urls.ts
+++ b/extension/src/helpers/urls.ts
@@ -4,3 +4,7 @@ export const parsedSearchParam = (param: string) => {
   const decodedSearchParam = atob(param.replace("?", ""));
   return decodedSearchParam ? JSON.parse(decodedSearchParam) : {};
 };
+export const getUrlHostname = (url: string) => {
+  const u = new URL(url);
+  return u.hostname;
+};

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -2,7 +2,7 @@ import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 import { registerHandler, emitMetric } from "helpers/metrics";
 import { getTransactionInfo } from "helpers/stellar";
-import { parsedSearchParam } from "helpers/urls";
+import { parsedSearchParam, getUrlHostname } from "helpers/urls";
 
 import { navigate } from "popup/ducks/views";
 import { AppState } from "popup/App";
@@ -35,9 +35,9 @@ registerHandler<AppState>(navigate, (_, a) => {
   // "/sign-transaction" and "/grant-access" require additionak metrics on loaded page
   if (pathname === ROUTES.grantAccess) {
     const { url } = parsedSearchParam(search);
-    const u = new URL(url);
+    const hostname = getUrlHostname(url);
     const METRIC_OPTION_DOMAIN = {
-      domain: u.hostname,
+      domain: hostname,
     };
 
     emitMetric(eventName, METRIC_OPTION_DOMAIN);

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 import punycode from "punycode";
 
-import { parsedSearchParam } from "helpers/urls";
+import { parsedSearchParam, getUrlHostname } from "helpers/urls";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
@@ -47,8 +47,8 @@ export const GrantAccess = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const { url } = parsedSearchParam(location.search);
-  const u = new URL(url);
-  const punycodedDomain = punycode.toASCII(u.hostname);
+  const hostname = getUrlHostname(url);
+  const punycodedDomain = punycode.toASCII(hostname);
   const [isGranting, setIsGranting] = useState(false);
 
   const rejectAndClose = () => {

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
+import punycode from "punycode";
+
+import { parsedSearchParam } from "helpers/urls";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
@@ -43,9 +46,9 @@ const RejectButtonEl = styled(Button)`
 export const GrantAccess = () => {
   const location = useLocation();
   const dispatch = useDispatch();
-  const decodedTab = atob(location.search.replace("?", ""));
-  const tabToUnlock = decodedTab ? JSON.parse(decodedTab) : {};
-  const { url, title } = tabToUnlock;
+  const { url } = parsedSearchParam(location.search);
+  const u = new URL(url);
+  const punycodedDomain = punycode.toASCII(u.hostname);
   const [isGranting, setIsGranting] = useState(false);
 
   const rejectAndClose = () => {
@@ -62,7 +65,7 @@ export const GrantAccess = () => {
   return (
     <GrantAccessEl>
       <HeaderEl>Connection request</HeaderEl>
-      <SubheaderEl>{title} wants to know your public key</SubheaderEl>
+      <SubheaderEl>{punycodedDomain} wants to know your public key</SubheaderEl>
       <TextEl>
         This site is asking for access to the public key associated with this
         Lyra wallet. Only share your information with websites you trust.{" "}


### PR DESCRIPTION
<img width="453" alt="grant-access" src="https://user-images.githubusercontent.com/3912060/91497252-a71cc480-e88b-11ea-893a-ca46612332b9.png">

- `/grant-access` just needs url from its search params, not via transaction.
- Added punycode for `/grant-access` as well
- removed `{title}`
