### PR TITLE
bugfix/onboarding_new_window > close the window the user was on when the user is on /grant-access and has not completed onboarding process

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -105,6 +105,7 @@ const HomeRoute = () => {
     */
     if (window.innerWidth === POPUP_WIDTH) {
       window.open(newTabHref(ROUTES.welcome));
+      window.close();
     }
     return <Welcome />;
   }


### PR DESCRIPTION
Ticket: [When installing Lyra, if the user doesn't go through onboarding and just clicks on "connect with Lyra" on Lab, there's a a weird behavior](https://app.asana.com/0/1168666457741233/1187237204678443)

**The issue**: This bug happens when the extension is installed but the user has not completed onboarding. When the user clicks the button that calls for `getPublicKey()`, it opens `/grant-access` popup route by default. But because there's no public key available, `<GrantAccess/>` switched to `<Welcome/>` in the popup view in addition to opening a new tab with `<Welcome/>`.

I fixed it by closing the popup window if a user without a public key is on `/grant-access` popup view.