### PR TITLE
make lyraApi.signTransaction accept string as param

### DIFF
--- a/.github/workflows/buildPreview.yml
+++ b/.github/workflows/buildPreview.yml
@@ -3,7 +3,7 @@ name: Compile extension PR preview
 on:
   pull_request:
     paths:
-      - "./extension/**"
+      - "./extension/*/**"
 
 jobs:
   build:

--- a/.github/workflows/buildPreview.yml
+++ b/.github/workflows/buildPreview.yml
@@ -3,7 +3,7 @@ name: Compile extension PR preview
 on:
   pull_request:
     paths:
-      - "./extension/*/**"
+      - "./extension/**"
 
 jobs:
   build:

--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -1,6 +1,5 @@
 import { EXTERNAL_SERVICE_TYPES } from "../constants/services";
 import { sendMessageToContentScript } from "./helpers";
-import { LyraApiRequest } from "./types";
 
 export const requestPublicKey = async (): Promise<string> => {
   let response = { publicKey: "", error: "" };
@@ -20,9 +19,9 @@ export const requestPublicKey = async (): Promise<string> => {
   return publicKey;
 };
 
-export const submitTransaction = async ({
-  transactionXdr,
-}: LyraApiRequest): Promise<string> => {
+export const submitTransaction = async (
+  transactionXdr: string,
+): Promise<string> => {
   let response = { signedTransaction: "", error: "" };
   try {
     response = await sendMessageToContentScript({

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -21,10 +21,6 @@ export interface Response {
   url: string;
 }
 
-export interface LyraApiRequest {
-  transactionXdr: string;
-}
-
-export interface ExternalRequest extends LyraApiRequest {
+export interface ExternalRequest {
   type: EXTERNAL_SERVICE_TYPES;
 }

--- a/@stellar/lyra-api/src/signTransaction.ts
+++ b/@stellar/lyra-api/src/signTransaction.ts
@@ -1,5 +1,4 @@
 import { submitTransaction } from "@shared/api/external";
-import { LyraApiRequest } from "@shared/api/types";
 
-export const signTransaction = (params: LyraApiRequest) =>
-  submitTransaction(params);
+export const signTransaction = (transactionXdr: string) =>
+  submitTransaction(transactionXdr);

--- a/docs/docs/guide/usingLyra.md
+++ b/docs/docs/guide/usingLyra.md
@@ -37,7 +37,7 @@ if (isConnected()) {
 
 ### getPublicKey
 
-#### `getPublicKey() -> <Promise<{ publicKey: string; error?: string; }>>`
+#### `getPublicKey() -> <Promise<string>>`
 
 If a user has never interacted with your app before, this function will prompt the user to provide your app privileges to receive the user's public key. If and when the user accepts, this function will resolve with an object containing the public key. Otherwise, it will provide an error.
 
@@ -72,7 +72,7 @@ const result = retrievePublicKey();
 
 ### signTransaction
 
-#### `signTransaction({ transactionXdr: string }) -> <Promise<{ signedTransaction: string; error?: string;}>>`
+#### `signTransaction(string) -> <Promise<string>>`
 
 This function accepts an object containing an transaction XDR string, which it will decode, sign as the user, and then return the signed transaction to your application.
 
@@ -111,7 +111,7 @@ const userSignTransaction = async (xdr: String) => {
   let error = "";
 
   try {
-    res = await signTransaction({ transactionXdr: xdr });
+    res = await signTransaction(xdr);
   } catch (e) {
     error = e;
   }

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -13,7 +13,7 @@ export const SignTransactionDemo = () => {
     let error = "";
 
     try {
-      signedTransaction = await signTransaction({ transactionXdr });
+      signedTransaction = await signTransaction(transactionXdr);
     } catch (e) {
       error = e;
     }

--- a/extension/src/background/messageListener/lyraApiMessageListener.ts
+++ b/extension/src/background/messageListener/lyraApiMessageListener.ts
@@ -64,7 +64,7 @@ export const lyraApiMessageListener = (
   };
 
   const submitTransaction = () => {
-    const { transactionXdr } = request;
+    const transactionXdr = request;
 
     const transaction = StellarSdk.TransactionBuilder.fromXDR(
       transactionXdr,


### PR DESCRIPTION
https://app.asana.com/0/1168666457741233/1188069176357563

This is an improvement Iveta found while she was integrating with AV. This method just needs an xdr string. Instead of passing { transactionXdr: string; }, let's just pass it a string to make things simpler  