### PR TITLE
Set the extension's height to 600px which is Chrome extension's max height value

### DIFF
--- a/extension/src/constants/dimensions.ts
+++ b/extension/src/constants/dimensions.ts
@@ -1,3 +1,4 @@
 export const POPUP_WIDTH = 456;
+export const POPUP_HEIGHT = 600;
 
 export const HEADER_HEIGHT = 120;

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -8,7 +8,7 @@ import { metricsMiddleware } from "helpers/metrics";
 
 import { COLOR_PALETTE } from "popup/constants/styles";
 import { reducer as auth } from "popup/ducks/authServices";
-import { POPUP_WIDTH } from "constants/dimensions";
+import { POPUP_WIDTH, POPUP_HEIGHT } from "constants/dimensions";
 import { Header } from "popup/components/Header";
 
 import { Router } from "./Router";
@@ -27,7 +27,7 @@ const GlobalStyle = createGlobalStyle`
     width: ${POPUP_WIDTH}px;
   }
   body, html, #root {
-    height: 100vh;
+    height: ${POPUP_HEIGHT}px;
   }
 
   body * {


### PR DESCRIPTION
Ticket: [Extension popup shouldn't scroll left/right](https://app.asana.com/0/1168666457741233/1189755955263475)
- I couldn't find the case where the extension was scrolling left to right. @vcarl, do you remember which stage this was happening?
- I added its extension height to be chrome extension's max height (600px)

