### PR TITLE
grant access > notify users to agree to provide their public key to a third party service for the first time

### DIFF
--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -1,10 +1,14 @@
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { useLocation } from "react-router-dom";
 import punycode from "punycode";
 
-import { parsedSearchParam, getUrlHostname } from "helpers/urls";
+import {
+  removeQueryParam,
+  parsedSearchParam,
+  getUrlHostname,
+} from "helpers/urls";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
@@ -12,6 +16,8 @@ import { Button } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
 
 import "popup/metrics/access";
+
+const WHITELIST_ID = "whitelist";
 
 const GrantAccessEl = styled.div`
   padding: 2.25rem 2.5rem;
@@ -34,13 +40,37 @@ const TextEl = styled.p`
   padding: 1.7rem 2rem;
   margin: 0;
 `;
+
+interface ButtonContainerProps {
+  isColumnDirection: boolean;
+}
+
 const ButtonContainerEl = styled.div`
   display: flex;
   justify-content: space-around;
   padding: 3rem 1.25rem;
+  flex-direction: row;
+
+  ${({ isColumnDirection }: ButtonContainerProps) =>
+    isColumnDirection &&
+    css`
+      flex-direction: column;
+      padding: 0 1.25rem;
+
+      button {
+        width: 100%;
+        margin-bottom: 0.625rem;
+      }
+    `}
 `;
 const RejectButtonEl = styled(Button)`
   background: ${COLOR_PALETTE.text};
+`;
+const WarningMessageEl = styled.div`
+  background-color: ${COLOR_PALETTE.errorFaded};
+  padding: 0.5rem 1rem;
+  text-align: center;
+  font-size: 0.85rem;
 `;
 
 export const GrantAccess = () => {
@@ -50,6 +80,10 @@ export const GrantAccess = () => {
   const hostname = getUrlHostname(url);
   const punycodedDomain = punycode.toASCII(hostname);
   const [isGranting, setIsGranting] = useState(false);
+
+  const whitelistStr = localStorage.getItem(WHITELIST_ID) || "";
+  const whitelist = whitelistStr.split(",");
+  const isDomainWhiteListed = whitelist.includes(removeQueryParam(url));
 
   const rejectAndClose = () => {
     dispatch(rejectAccess());
@@ -66,21 +100,38 @@ export const GrantAccess = () => {
     <GrantAccessEl>
       <HeaderEl>Connection request</HeaderEl>
       <SubheaderEl>{punycodedDomain} wants to know your public key</SubheaderEl>
+      {!isDomainWhiteListed ? (
+        <WarningMessageEl>
+          <p>
+            <strong>
+              This is the first time you interact with this domain in this
+              computer.
+            </strong>
+          </p>
+          <p>
+            Make sure the domain name above reads as it should, if you suspect
+            of something, don't give ir permission. If you interacted with this
+            domain before in this browser, this might indicate a scam.
+          </p>
+        </WarningMessageEl>
+      ) : null}
       <TextEl>
         This site is asking for access to the public key associated with this
         Lyra wallet. Only share your information with websites you trust.{" "}
       </TextEl>
-      <ButtonContainerEl>
-        <RejectButtonEl size="small" onClick={rejectAndClose}>
-          Reject
-        </RejectButtonEl>
+      <ButtonContainerEl isColumnDirection={!isDomainWhiteListed}>
         <SubmitButton
           isSubmitting={isGranting}
           size="small"
           onClick={() => grantAndClose()}
         >
-          Confirm
+          {isDomainWhiteListed
+            ? "Confirm"
+            : "Trust this domain and share public key"}
         </SubmitButton>
+        <RejectButtonEl size="small" onClick={rejectAndClose}>
+          Reject
+        </RejectButtonEl>
       </ButtonContainerEl>
     </GrantAccessEl>
   );

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -110,7 +110,7 @@ export const GrantAccess = () => {
           </p>
           <p>
             Make sure the domain name above reads as it should, if you suspect
-            of something, don't give ir permission. If you interacted with this
+            of something, don't give it permission. If you‘ve interacted with this
             domain before in this browser, this might indicate a scam.
           </p>
         </WarningMessageEl>

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -104,7 +104,7 @@ export const GrantAccess = () => {
         <WarningMessageEl>
           <p>
             <strong>
-              This is the first time you interact with this domain in this
+              This is the first time you‘ve interacted with this domain on this
               computer.
             </strong>
           </p>


### PR DESCRIPTION
Ticket: [Notify users to agree to provide their public key to a third party service for the first time](https://app.asana.com/0/1168666457741233/1193011684416067)

We do not have design for this yet. It's based on the [wireframe](https://www.figma.com/file/uIoeq72R2XjiWjGyVGiPG6/Lyra-wireframes?node-id=410%3A142) that Bruno provided. **I think we should gather the components/pages that are only based on wireframes and not design**. There are quiet few I think.

**Asking users to agree to provide their public key to a third party service that they visited for the first time**
<img width="452" alt="firsttime-domain" src="https://user-images.githubusercontent.com/3912060/92664412-eeff0b00-f2d1-11ea-9ca5-06f60636ec8c.png">

**Once the domain is whitelisted**
<img width="457" alt="whitelisted-domain" src="https://user-images.githubusercontent.com/3912060/92664418-f0303800-f2d1-11ea-8119-d93e62722639.png">
