### PR TITLE
feature/remove-global-header > removing header from App.tsx as global

### DIFF
--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -9,7 +9,6 @@ import { metricsMiddleware } from "helpers/metrics";
 import { COLOR_PALETTE } from "popup/constants/styles";
 import { reducer as auth } from "popup/ducks/authServices";
 import { POPUP_WIDTH, POPUP_HEIGHT } from "constants/dimensions";
-import { Header } from "popup/components/Header";
 
 import { Router } from "./Router";
 
@@ -53,7 +52,6 @@ export function App() {
   return (
     <Provider store={store}>
       <GlobalStyle />
-      <Header />
       <Router />
     </Provider>
   );

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -33,6 +33,8 @@ import { UnlockAccount } from "popup/views/UnlockAccount";
 import { Welcome } from "popup/views/Welcome";
 import { Loading } from "popup/views/Loading";
 
+import { Header } from "popup/components/Header";
+
 import "popup/metrics/views";
 
 const PublicKeyRoute = (props: RouteProps) => {
@@ -146,30 +148,39 @@ export const Router = () => {
       <RouteListener />
       <Switch>
         <PublicKeyRoute path={ROUTES.account}>
+          <Header />
           <Account />
         </PublicKeyRoute>
         <PrivateKeyRoute path={ROUTES.signTransaction}>
+          <Header />
           <SignTransaction />
         </PrivateKeyRoute>
         <PublicKeyRoute path={ROUTES.grantAccess}>
+          <Header />
           <GrantAccess />
         </PublicKeyRoute>
         <PublicKeyRoute path={ROUTES.mnemonicPhrase}>
+          <Header />
           <MnemonicPhrase />
         </PublicKeyRoute>
         <Route path={ROUTES.unlockAccount}>
+          <Header />
           <UnlockAccount />
         </Route>
         <Route path={ROUTES.mnemonicPhraseConfirmed}>
+          <Header />
           <FullscreenSuccessMessage />
         </Route>
         <Route path={ROUTES.accountCreator}>
+          <Header />
           <AccountCreator />
         </Route>
         <Route path={ROUTES.recoverAccount}>
+          <Header />
           <RecoverAccount />
         </Route>
         <Route path={ROUTES.recoverAccountSuccess}>
+          <Header />
           <FullscreenSuccessMessage />
         </Route>
         <HomeRoute />

--- a/extension/src/popup/views/SignTransaction.tsx
+++ b/extension/src/popup/views/SignTransaction.tsx
@@ -5,9 +5,6 @@ import styled from "styled-components";
 import BigNumber from "bignumber.js";
 import punycode from "punycode";
 
-import { ROUTES } from "popup/constants/routes";
-
-import { navigateTo } from "popup/helpers/navigateTo";
 import { truncatedPublicKey, getTransactionInfo } from "helpers/stellar";
 
 import { OPERATION_TYPES } from "constants/operationTypes";
@@ -16,7 +13,7 @@ import { publicKeySelector } from "popup/ducks/authServices";
 import { rejectTransaction, signTransaction } from "popup/ducks/access";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
-import { Button, BackButton } from "popup/basics/Buttons";
+import { Button } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
 
 const El = styled.div`
@@ -227,7 +224,6 @@ export const SignTransaction = () => {
 
   return (
     <El>
-      <BackButton onClick={() => navigateTo(ROUTES.welcome)} />
       <HeaderEl>Confirm Transaction</HeaderEl>
       <SubheaderEl>{punycodedDomain} is requesting a transaction</SubheaderEl>
       <ListEl>


### PR DESCRIPTION
Updates:
- Removed `<Header/>` from `App.tsx` because some components do not carry a `<Header/>` component
- Removed `SignTransaction`'s back button since it is a popup, there is no back history.