### PR TITLE
bugfix/onboarding-validate-recovery-phase > moving 'navigateTo' to when calling mnemonicPhrase goes successfully

### DIFF
--- a/extension/src/popup/views/RecoverAccount.tsx
+++ b/extension/src/popup/views/RecoverAccount.tsx
@@ -71,17 +71,18 @@ export const RecoverAccount = () => {
 
   const handleSubmit = async (values: FormValues) => {
     const { password, mnemonicPhrase } = values;
+
     await dispatch(
       recoverAccount({
         password,
         mnemonicPhrase: mnemonicPhrase.trim(),
       }),
     );
-    navigateTo(ROUTES.recoverAccountSuccess);
   };
 
   useEffect(() => {
     if (publicKey) {
+      navigateTo(ROUTES.recoverAccountSuccess);
       window.close();
     }
   }, [publicKey]);


### PR DESCRIPTION
**Summary:**
- `navigateTo()` function was included in `handleSubmit` so regardless of its result (success or fail), it led to a successful page. It's now within `useEffect` where it checks if publicKey is available