### PR TITLE
feature/password-requirements > <PasswordRequirements/> added

### DIFF
--- a/extension/src/popup/basics/Forms.tsx
+++ b/extension/src/popup/basics/Forms.tsx
@@ -80,7 +80,7 @@ export const Error = ({ name }: { name: string }) => (
 
 export const Label = styled.label`
   color: ${COLOR_PALETTE.secondaryText};
-  font-size: 0.8125rem;
+  font-size: 0.9rem;
 `;
 
 export const TextField = styled(Field)`

--- a/extension/src/popup/components/Footer.tsx
+++ b/extension/src/popup/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+
 import { COLOR_PALETTE } from "popup/constants/styles";
 
 const FooterEl = styled.footer`

--- a/extension/src/popup/components/PasswordRequirements.tsx
+++ b/extension/src/popup/components/PasswordRequirements.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+
+import { COLOR_PALETTE } from "popup/constants/styles";
+
+const El = styled.div`
+  padding: 1.25rem 0 2.5rem;
+`;
+
+const ListEl = styled.ul`
+  color: ${COLOR_PALETTE.secondaryText};
+  list-style-type: disc;
+  list-style-position: inside;
+  font-size: 0.9rem;
+  padding: 0;
+  margin: 0;
+`;
+
+export const PasswordRequirements = () => (
+  <El>
+    <ListEl>
+      <li>Must be at least 10 characters long</li>
+      <li>Must contain an uppercase and lowercase letter</li>
+      <li>Must contain a number</li>
+    </ListEl>
+  </El>
+);

--- a/extension/src/popup/views/Account.tsx
+++ b/extension/src/popup/views/Account.tsx
@@ -15,6 +15,7 @@ import { ROUTES } from "popup/constants/routes";
 
 import { COLOR_PALETTE } from "popup/constants/styles";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
+
 import { BasicButton } from "popup/basics/Buttons";
 
 import { Toast } from "popup/components/Toast";

--- a/extension/src/popup/views/AccountCreator.tsx
+++ b/extension/src/popup/views/AccountCreator.tsx
@@ -5,11 +5,16 @@ import { Formik } from "formik";
 import { object as YupObject } from "yup";
 
 import { ROUTES } from "popup/constants/routes";
+import { EMOJI } from "popup/constants/emoji";
 
 import { navigateTo } from "popup/helpers/navigateTo";
+import {
+  password as passwordValidator,
+  confirmPassword as confirmPasswordValidator,
+  termsOfUse as termsofUseValidator,
+} from "popup/helpers/validators";
 import { createAccount, publicKeySelector } from "popup/ducks/authServices";
 
-import { Onboarding, HalfScreen } from "popup/components/Onboarding";
 import {
   Form,
   SubmitButton,
@@ -18,12 +23,9 @@ import {
   CheckboxField,
   TextField,
 } from "popup/basics/Forms";
-import {
-  password as passwordValidator,
-  confirmPassword as confirmPasswordValidator,
-  termsOfUse as termsofUseValidator,
-} from "popup/helpers/validators";
-import { EMOJI } from "popup/constants/emoji";
+
+import { Onboarding, HalfScreen } from "popup/components/Onboarding";
+import { PasswordRequirements } from "popup/components/PasswordRequirements";
 
 const ModifiedHalfScreenEl = styled(HalfScreen)`
   padding-left: 1.55rem;
@@ -64,7 +66,6 @@ export const AccountCreator = () => {
   return (
     <Onboarding
       header="Create a password"
-      subheader="Min 10 characters"
       icon={EMOJI.see_no_evil}
       goBack={() => navigateTo(ROUTES.welcome)}
     >
@@ -94,6 +95,7 @@ export const AccountCreator = () => {
                 />
                 <Error name="confirmPassword" />
               </FormRow>
+              <PasswordRequirements />
               <FormRow>
                 <CheckboxField
                   name="termsOfUse"

--- a/extension/src/popup/views/RecoverAccount.tsx
+++ b/extension/src/popup/views/RecoverAccount.tsx
@@ -4,6 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { Formik } from "formik";
 import { object as YupObject } from "yup";
 
+import { HEADER_HEIGHT } from "constants/dimensions";
+
 import { ROUTES } from "popup/constants/routes";
 
 import { navigateTo } from "popup/helpers/navigateTo";
@@ -19,8 +21,6 @@ import {
   recoverAccount,
 } from "popup/ducks/authServices";
 
-import { HEADER_HEIGHT } from "constants/dimensions";
-
 import {
   ApiErrorMessage,
   Error,
@@ -30,7 +30,9 @@ import {
   SubmitButton,
   Form,
 } from "popup/basics/Forms";
+
 import { Onboarding, HalfScreen } from "popup/components/Onboarding";
+import { PasswordRequirements } from "popup/components/PasswordRequirements";
 
 const FullHeightFormEl = styled(Form)`
   height: calc(100vh - ${HEADER_HEIGHT}px);
@@ -135,6 +137,7 @@ export const RecoverAccount = () => {
                   />
                   <Error name="confirmPassword" />
                 </FormRow>
+                <PasswordRequirements />
                 <FormRow>
                   <CheckboxField
                     label={


### PR DESCRIPTION
**Summary:**
- Password Requirements added. It is being used in two places `<AccountCreator/>` and `<RecoveryAccount/>` so I created it as a component
- Font size for Terms of Services' `label` and requirements text are the same on Figma so I assigned the same font size for both (increased the size for Terms of Services)
- Shuffled the imports to match our [Product Conventions](https://github.com/stellar/product-conventions/blob/master/STYLEGUIDE.md#imports)

**Screenshots:**
- Account Creator
<img width="1098" alt="password-requirements-account-creator" src="https://user-images.githubusercontent.com/3912060/94308214-28777d80-ff44-11ea-88f2-9e8e5d6196af.png">

- Recovery Account
<img width="1110" alt="password-requirements-recovery" src="https://user-images.githubusercontent.com/3912060/94308209-27dee700-ff44-11ea-811f-914cfd64aafd.png">