### PR TITLE
feature/style-warning-message > a warning message component added

### DIFF
--- a/docs/docs/playground/components/GetPublicKeyDemo.tsx
+++ b/docs/docs/playground/components/GetPublicKeyDemo.tsx
@@ -6,16 +6,15 @@ export const GetPublicKeyDemo = () => {
   const [publicKeyResult, setPublicKeyResult] = useState("");
 
   const btnHandler = async () => {
-    let response = { publicKey: "" };
+    let publicKey;
     let error = "";
 
     try {
-      response = await getPublicKey();
+      publicKey = await getPublicKey();
     } catch (e) {
       error = e;
     }
 
-    const { publicKey } = response;
     setPublicKeyResult(publicKey || error);
   };
 

--- a/docs/docs/playground/components/GetPublicKeyDemo.tsx
+++ b/docs/docs/playground/components/GetPublicKeyDemo.tsx
@@ -4,16 +4,21 @@ import { PlaygroundInput } from "./basics/inputs";
 
 export const GetPublicKeyDemo = () => {
   const [publicKeyResult, setPublicKeyResult] = useState("");
+
   const btnHandler = async () => {
-    let publicKey;
+    let response = { publicKey: "" };
     let error = "";
+
     try {
-      publicKey = await getPublicKey();
+      response = await getPublicKey();
     } catch (e) {
       error = e;
     }
+
+    const { publicKey } = response;
     setPublicKeyResult(publicKey || error);
   };
+
   return (
     <section>
       <div>

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -13,9 +13,7 @@ export const SignTransactionDemo = () => {
     let error = "";
 
     try {
-      signedTransaction = await signTransaction({
-        transactionXdr,
-      });
+      signedTransaction = await signTransaction(transactionXdr);
     } catch (e) {
       error = e;
     }

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -13,7 +13,9 @@ export const SignTransactionDemo = () => {
     let error = "";
 
     try {
-      signedTransaction = await signTransaction(transactionXdr);
+      signedTransaction = await signTransaction({
+        transactionXdr,
+      });
     } catch (e) {
       error = e;
     }

--- a/docs/docs/playground/signTransaction.mdx
+++ b/docs/docs/playground/signTransaction.mdx
@@ -3,7 +3,7 @@ id: signTransaction
 title: signTransaction
 ---
 
-#### `signTransaction({ transactionXdr: string })`
+#### `signTransaction( transactionXdr: string )`
 
 import { SignTransactionDemo } from "./components/SignTransactionDemo";
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "@docusaurus/core": "^2.0.0-alpha.61",
     "@docusaurus/preset-classic": "^2.0.0-alpha.60",
     "@mdx-js/react": "^1.5.8",
-    "@stellar/lyra-api": "1.0.0",
+    "@stellar/lyra-api": "1.0.0-alpha.3",
     "clsx": "^1.1.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "@docusaurus/core": "^2.0.0-alpha.61",
     "@docusaurus/preset-classic": "^2.0.0-alpha.60",
     "@mdx-js/react": "^1.5.8",
-    "@stellar/lyra-api": "1.0.0-alpha.2",
+    "@stellar/lyra-api": "1.0.0",
     "clsx": "^1.1.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/extension/src/popup/assets/icon-orange-lock.svg
+++ b/extension/src/popup/assets/icon-orange-lock.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 13a2 2 0 100 4 2 2 0 000-4z" fill="#E4792C"/><path d="M7 9V7a5 5 0 0110 0v2M6 21h12a1 1 0 001-1V10a1 1 0 00-1-1H6a1 1 0 00-1 1v10a1 1 0 001 1z" stroke="#E4792C" stroke-width="2" stroke-miterlimit="10"/></svg>

--- a/extension/src/popup/assets/icon-warning-shield.svg
+++ b/extension/src/popup/assets/icon-warning-shield.svg
@@ -1,0 +1,1 @@
+<svg width="32" height="32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16 20v2m0 5S6 22.991 6 8c4.966 0 6-3 10-3s5.057 3 10 3c0 15.047-10 19-10 19zm0-18v9-9z" stroke="#E4792C" stroke-width="2" stroke-miterlimit="10"/></svg>

--- a/extension/src/popup/assets/icon-white-lock.svg
+++ b/extension/src/popup/assets/icon-white-lock.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 13a2 2 0 100 4 2 2 0 000-4z" fill="#fff"/><path d="M7 9V7a5 5 0 0110 0v2M6 21h12a1 1 0 001-1V10a1 1 0 00-1-1H6a1 1 0 00-1 1v10a1 1 0 001 1z" stroke="#fff" stroke-width="2" stroke-miterlimit="10"/></svg>

--- a/extension/src/popup/basics/Buttons.tsx
+++ b/extension/src/popup/basics/Buttons.tsx
@@ -77,11 +77,11 @@ const BackButtonEl = styled(BasicButton)`
   left: 1rem;
   display: flex;
   align-items: center;
-  background: ${COLOR_PALETTE.inputBackground};
+  background: ${COLOR_PALETTE.greyFaded};
   border-radius: 0.625rem;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.3rem;
+  height: 2.3rem;
 
   img {
     transform: rotate(180deg);

--- a/extension/src/popup/components/WarningMessage.tsx
+++ b/extension/src/popup/components/WarningMessage.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+
+import { FONT_WEIGHT, COLOR_PALETTE } from "popup/constants/styles";
+
+const El = styled.div`
+  border-radius: 1.25rem;
+  background-color: ${COLOR_PALETTE.warningFaded};
+  padding: 1.5rem 1.25rem;
+  text-align: left;
+  font-size: 0.93rem;
+  margin: 1.25rem 0;
+
+  p {
+    font-size: 0.93rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+const HeadingEl = styled.div`
+  display: flex;
+  align-items: center;
+`;
+const IconEl = styled.img`
+  max-width: 1.875rem;
+  max-height: 1.875rem;
+`;
+const SubheaderEl = styled.h2`
+  color: ${COLOR_PALETTE.warning};
+  font-weight: ${FONT_WEIGHT.bold};
+  font-size: 1.1rem;
+  max-width: 23rem;
+  padding-left: 0.65rem;
+  margin: 0;
+`;
+
+export const WarningMessage = ({
+  subheader,
+  icon,
+  children,
+}: {
+  subheader: string;
+  icon: string;
+  children: React.ReactNode;
+}) => (
+  <El>
+    <HeadingEl>
+      <IconEl src={icon} alt="Warning Message Icon" />
+      <SubheaderEl>{subheader}</SubheaderEl>
+    </HeadingEl>
+    {children}
+  </El>
+);

--- a/extension/src/popup/constants/styles.tsx
+++ b/extension/src/popup/constants/styles.tsx
@@ -12,10 +12,11 @@ export const COLOR_PALETTE = {
   error: "#F42703",
   errorFaded: "#FFBFBF",
   greyFaded: "#D2D5DB",
+  warning: "#E4792C",
+  warningFaded: "#F8E4CC",
   primaryGradient: "linear-gradient(180deg, #4b42e3 0%, #302cd1 100%)",
   darkPrimaryGradient: "linear-gradient(180deg, #443BDB 0%, #2521C3 100%)",
   menuGradient: "linear-gradient(180deg, #564df0 0%, #2d18b5 100%)",
-  warningGradient: "linear-gradient(180deg, #ed5c40 0%, #e33d24 100%)",
 };
 
 export const Z_INDEXES = {

--- a/extension/src/popup/views/DisplayBackupPhrase.tsx
+++ b/extension/src/popup/views/DisplayBackupPhrase.tsx
@@ -17,6 +17,7 @@ import { Button } from "popup/basics/Buttons";
 
 import { Toast } from "popup/components/Toast";
 import { ActionButton } from "popup/components/mnemonicPhrase/ActionButton";
+import { WarningMessage } from "popup/components/WarningMessage";
 
 import {
   HeaderContainerEl,
@@ -24,6 +25,7 @@ import {
   BackButtonEl,
 } from "popup/views/UnlockBackupPhrase";
 
+import OrangeLockIcon from "popup/assets/icon-orange-lock.svg";
 import DownloadColorIcon from "popup/assets/download-color.svg";
 import CopyColorIcon from "popup/assets/copy-color.svg";
 
@@ -34,16 +36,14 @@ const MnemonicDisplayEl = styled.div`
   border: 2px solid ${COLOR_PALETTE.primary};
   border-radius: 20px;
   font-size: 1.125rem;
-  margin: 2rem 0 1rem;
+  margin: 0;
+  margin-bottom: 1rem;
   padding: 1rem;
   position: relative;
 `;
-
 const DisplayButtonsEl = styled.div`
   color: ${COLOR_PALETTE.primary};
   font-weight: ${FONT_WEIGHT.bold};
-  margin-bottom: 2.5rem;
-  margin-right: 1rem;
   position: relative;
   text-align: right;
 
@@ -64,11 +64,20 @@ const UnlockAccountEl = styled.div`
   padding: 2rem 2.5rem;
 `;
 const ButtonRowEl = styled.div`
-  padding: 1.5rem 0;
+  padding: 1.15rem 0 0;
 `;
 const ActionButtonEl = styled(ActionButton)`
+  padding: 0 0.75rem;
   color: ${COLOR_PALETTE.primary};
   opacity: 1;
+`;
+const H3 = styled.h3`
+  font-weight: ${FONT_WEIGHT.normal};
+  color: ${COLOR_PALETTE.primary};
+  font-size: 1.125rem;
+  line-height: 2;
+  margin: 0;
+  padding: 0 2px;
 `;
 
 export const DisplayBackupPhrase = () => {
@@ -81,15 +90,17 @@ export const DisplayBackupPhrase = () => {
         <BackButtonEl onClick={() => navigateTo(ROUTES.account)} />
         <HeaderEl>Show backup phrase</HeaderEl>
       </HeaderContainerEl>
-      {/* TODO: REPLACE THE ERROR MESSAGE WITH ERROR MESSAGE COMPONENT */}
-      <div>
-        <p>Keep your phrase in a safe place</p>
+      <WarningMessage
+        icon={OrangeLockIcon}
+        subheader="Keep your phrase in a safe place"
+      >
         <p>Your backup phrase is the only way to recover your account.</p>
         <p>
           Anyone who has access to your phrase has access to your account and to
           the funds in it, so keep it noted in a safe place.
         </p>
-      </div>
+      </WarningMessage>
+      <H3>Your backup phrase:</H3>
       <MnemonicDisplayEl>{mnemonicPhrase}</MnemonicDisplayEl>
       <DisplayButtonsEl>
         <ActionButtonEl

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -12,20 +12,24 @@ import {
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
+
 import { Button } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
+import { WarningMessage } from "popup/components/WarningMessage";
+
+import WarningShieldIcon from "popup/assets/icon-warning-shield.svg";
 
 import "popup/metrics/access";
 
 const WHITELIST_ID = "whitelist";
 
 const GrantAccessEl = styled.div`
-  padding: 2.25rem 2.5rem;
+  padding: 1.5rem 1.875rem;
 `;
 const HeaderEl = styled.h1`
   color: ${COLOR_PALETTE.primary}};
   font-weight: ${FONT_WEIGHT.light};
-  margin: 1rem 0 0.75rem;
+  margin: 0;
 `;
 const SubheaderEl = styled.h3`
   font-weight: ${FONT_WEIGHT.bold};
@@ -66,24 +70,20 @@ const ButtonContainerEl = styled.div`
 const RejectButtonEl = styled(Button)`
   background: ${COLOR_PALETTE.text};
 `;
-const WarningMessageEl = styled.div`
-  background-color: ${COLOR_PALETTE.errorFaded};
-  padding: 0.5rem 1rem;
-  text-align: center;
-  font-size: 0.85rem;
-`;
 
 export const GrantAccess = () => {
   const location = useLocation();
   const dispatch = useDispatch();
+  const [isGranting, setIsGranting] = useState(false);
+
   const { url } = parsedSearchParam(location.search);
   const hostname = getUrlHostname(url);
   const punycodedDomain = punycode.toASCII(hostname);
-  const [isGranting, setIsGranting] = useState(false);
-
   const whitelistStr = localStorage.getItem(WHITELIST_ID) || "";
   const whitelist = whitelistStr.split(",");
-  const isDomainWhiteListed = whitelist.includes(removeQueryParam(url));
+  const isDomainWhiteListed = whitelist.includes(
+    removeQueryParam(punycodedDomain),
+  );
 
   const rejectAndClose = () => {
     dispatch(rejectAccess());
@@ -98,27 +98,24 @@ export const GrantAccess = () => {
 
   return (
     <GrantAccessEl>
-      <HeaderEl>Connection request</HeaderEl>
-      <SubheaderEl>{punycodedDomain} wants to know your public key</SubheaderEl>
+      <HeaderEl>Share public key</HeaderEl>
       {!isDomainWhiteListed ? (
-        <WarningMessageEl>
+        <WarningMessage
+          icon={WarningShieldIcon}
+          subheader="This is the first time you interact with this domain in this browser"
+        >
           <p>
-            <strong>
-              This is the first time you‘ve interacted with this domain on this
-              computer.
-            </strong>
+            Double check the domain name, if you suspect of something, don't
+            give it access.
           </p>
           <p>
-            Make sure the domain name above reads as it should, if you suspect
-            of something, don't give it permission. If you‘ve interacted with this
-            domain before in this browser, this might indicate a scam.
+            If you interacted with this domain before in this browser and are
+            seeing this message, it may indicate a scam.
           </p>
-        </WarningMessageEl>
+        </WarningMessage>
       ) : null}
-      <TextEl>
-        This site is asking for access to the public key associated with this
-        Lyra wallet. Only share your information with websites you trust.{" "}
-      </TextEl>
+      <SubheaderEl>{punycodedDomain} wants to know your public key</SubheaderEl>
+      <TextEl>This website wants to know your public key:</TextEl>
       <ButtonContainerEl isColumnDirection={!isDomainWhiteListed}>
         <SubmitButton
           isSubmitting={isGranting}

--- a/extension/src/popup/views/UnlockBackupPhrase.tsx
+++ b/extension/src/popup/views/UnlockBackupPhrase.tsx
@@ -24,11 +24,15 @@ import {
   TextField,
 } from "popup/basics/Forms";
 
+import { WarningMessage } from "popup/components/WarningMessage";
+
+import OrangeLockIcon from "popup/assets/icon-orange-lock.svg";
+
 const UnlockAccountEl = styled.div`
   width: 100%;
   max-width: ${POPUP_WIDTH}px;
   box-sizing: border-box;
-  padding: 2.25rem 2.5rem;
+  padding: 2.68rem 2.18rem;
 `;
 export const HeaderContainerEl = styled.div`
   display: flex;
@@ -36,13 +40,14 @@ export const HeaderContainerEl = styled.div`
   justify-content: flex-start;
   padding: 0;
   line-height: 1;
+  margin-bottom: 2.5rem;
 `;
 export const HeaderEl = styled.h1`
   color: ${COLOR_PALETTE.primary}};
   font-weight: ${FONT_WEIGHT.light};
   font-size: 1.56rem;
-  margin: 1rem 0 0.75rem;
-  padding-left: 0.625rem;
+  margin: 0;
+  padding-left: 1rem;
 `;
 export const BackButtonEl = styled(BackButton)`
   position: relative;
@@ -56,7 +61,7 @@ const ButtonRowEl = styled.div`
   padding: 1.5rem 0;
 `;
 const FormRowEl = styled(FormRow)`
-  padding: 3.25rem 0 0.15rem;
+  padding: 2rem 0 0.15rem;
 `;
 
 export const UnlockBackupPhrase = () => {
@@ -93,16 +98,16 @@ export const UnlockBackupPhrase = () => {
         <BackButtonEl onClick={() => navigateTo(ROUTES.account)} />
         <HeaderEl>Show backup phrase</HeaderEl>
       </HeaderContainerEl>
-
-      {/* TODO: REPLACE THE ERROR MESSAGE WITH ERROR MESSAGE COMPONENT */}
-      <div>
-        <p>Keep your phrase in a safe place</p>
+      <WarningMessage
+        icon={OrangeLockIcon}
+        subheader="Keep your phrase in a safe place"
+      >
         <p>Your backup phrase is the only way to recover your account.</p>
         <p>
           Anyone who has access to your phrase has access to your account and to
           the funds in it, so keep it noted in a safe place.
         </p>
-      </div>
+      </WarningMessage>
       <Formik onSubmit={handleSubmit} initialValues={initialValues}>
         {({ isSubmitting, isValid }) => (
           <Form>
@@ -111,7 +116,7 @@ export const UnlockBackupPhrase = () => {
                 autoComplete="off"
                 type="password"
                 name="password"
-                placeholder="Enter password"
+                placeholder="Enter your password"
                 error={errorMessage}
               />
             </FormRowEl>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,6 +1924,11 @@
   resolved "https://registry.yarnpkg.com/@stellar/eslint-config/-/eslint-config-1.0.5.tgz#00616eb6342e839ffa5c0d9e2539dccd64ede764"
   integrity sha512-RpkhdJffBU1oEsdyAJgfKHDSRJCWbyNOp08F1UP0yGp1tBLp0FopURl7m1Nx2Xd1o1PkN6h01wV6lpdiCbZWYQ==
 
+"@stellar/lyra-api@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@stellar/lyra-api/-/lyra-api-1.0.0.tgz#61fa093db7207d642c6d216feabdeda619badd5e"
+  integrity sha512-BDcDxvVoK1ffGq+Uz6/ocRR0GOcbplbgIu9H5i1q660U35uN63prAC4st3jK4Pxdu4wLowk8/TWN2xB0aWcCRg==
+
 "@stellar/prettier-config@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stellar/prettier-config/-/prettier-config-1.0.1.tgz#498a66dc13c66859e3787dabdf958233ddbe9253"


### PR DESCRIPTION
**Summary:**
- Created a warning message component `<WarningMessage/>` for the first time visiting the domain and keep backup phrase safe message
- SVG icons added for warning message component
- **FYI** that `Connection request` has been renamed to `Share Public Key`. Will update the components' name
- **FYI** that we need to whitelist domains on Sign Transaction view
- Updated `GetPublicKeyDemo` and `SignTransactionDemo` to follow the latest API structure

**Screenshots:**
Warning Message for Display Backup Phrase with Toast
<img width="390" alt="warning-msg-show-backup-toast" src="https://user-images.githubusercontent.com/3912060/94498693-c8453d80-01c8-11eb-8ffd-39bdf62efc9b.png">

Warning Message for Display Backup Phrase
<img width="458" alt="warning-msg-show-backup-02" src="https://user-images.githubusercontent.com/3912060/94498694-c8453d80-01c8-11eb-80e4-b26dc49e8421.png">

Warning Message for Show Backup Phrase
<img width="459" alt="warning-msg-show-backup" src="https://user-images.githubusercontent.com/3912060/94498695-c8ddd400-01c8-11eb-949d-99ddb92f4c0b.png">

Warning Message for Confirm Transaction
<img width="455" alt="warning-msg-confirm-transaction" src="https://user-images.githubusercontent.com/3912060/94498696-c8ddd400-01c8-11eb-8c93-0bc3828e6860.png">

Warning Message for Share Public Key
<img width="454" alt="warning-msg-share-public-key" src="https://user-images.githubusercontent.com/3912060/94498697-c8ddd400-01c8-11eb-8d9c-87a38db36649.png">

