### PR TITLE
feature/punycode-domain > <PunycodedDomain/> created

### DIFF
--- a/extension/src/popup/components/PunycodedDomain.tsx
+++ b/extension/src/popup/components/PunycodedDomain.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import styled from "styled-components";
+
+import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
+
+import { getPunycodedDomain } from "helpers/urls";
+
+const El = styled.div`
+  display: flex;
+  background: ${COLOR_PALETTE.white};
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  margin: 1.25rem 0px;
+`;
+const FaviconEl = styled.div`
+  padding-right: 1.125rem;
+`;
+const DomainEl = styled.div`
+  display: flex;
+`;
+const PunycodedDomainEl = styled.div`
+  color: ${COLOR_PALETTE.primary};
+  font-size: 1.18rem;
+  font-weight: ${FONT_WEIGHT.bold};
+`;
+const InvalidDomainEl = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const DecodedDomainEl = styled.span`
+  font-size: 0.875rem;
+  font-weight: ${FONT_WEIGHT.normal};
+`;
+
+export const PunycodedDomain = ({ domain, ...props }: { domain: string }) => {
+  const punycodedDomain = getPunycodedDomain(domain);
+  const isDomainValid = punycodedDomain === domain;
+
+  // @TODO faviocon
+  const favicon = false;
+
+  return (
+    <El {...props}>
+      {favicon ? <FaviconEl>hello</FaviconEl> : null}
+      <DomainEl>
+        {isDomainValid ? (
+          <PunycodedDomainEl>{punycodedDomain}</PunycodedDomainEl>
+        ) : (
+          <InvalidDomainEl>
+            <PunycodedDomainEl>xn-{punycodedDomain}</PunycodedDomainEl>
+            <DecodedDomainEl>{domain}</DecodedDomainEl>
+          </InvalidDomainEl>
+        )}
+      </DomainEl>
+    </El>
+  );
+};

--- a/extension/src/popup/components/Toast.tsx
+++ b/extension/src/popup/components/Toast.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
+
 import { COLOR_PALETTE } from "popup/constants/styles";
 
 const TOAST_LENGTH = 1000;

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -3,11 +3,7 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 
-import {
-  getUrlHostname,
-  parsedSearchParam,
-  getPunycodedDomain,
-} from "helpers/urls";
+import { getUrlHostname, parsedSearchParam } from "helpers/urls";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
@@ -15,6 +11,7 @@ import { rejectAccess, grantAccess } from "popup/ducks/access";
 import { Button } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
 import { WarningMessage } from "popup/components/WarningMessage";
+import { PunycodedDomain } from "popup/components/PunycodedDomain";
 
 import WarningShieldIcon from "popup/assets/icon-warning-shield.svg";
 
@@ -34,14 +31,6 @@ const SubheaderEl = styled.h3`
   letter-spacing: 0.1px;
   color: ${COLOR_PALETTE.primary}};
 `;
-const TextEl = styled.p`
-  font-size: 1.15rem;
-  text-align: center;
-  line-height: 1.9;
-  padding: 1.7rem 2rem;
-  margin: 0;
-`;
-
 const ButtonContainerEl = styled.div`
   display: flex;
   justify-content: space-around;
@@ -60,7 +49,6 @@ export const GrantAccess = () => {
   const { url } = parsedSearchParam(location.search);
 
   const domain = getUrlHostname(url);
-  const punycodedDomain = getPunycodedDomain(domain);
 
   const rejectAndClose = () => {
     dispatch(rejectAccess());
@@ -89,8 +77,8 @@ export const GrantAccess = () => {
           seeing this message, it may indicate a scam.
         </p>
       </WarningMessage>
-      <SubheaderEl>{punycodedDomain} wants to know your public key</SubheaderEl>
-      <TextEl>This website wants to know your public key:</TextEl>
+      <PunycodedDomain domain={domain} />
+      <SubheaderEl>This website wants to know your public key:</SubheaderEl>
       <ButtonContainerEl>
         <RejectButtonEl size="small" onClick={rejectAndClose}>
           Reject

--- a/extension/src/popup/views/SignTransaction.tsx
+++ b/extension/src/popup/views/SignTransaction.tsx
@@ -13,12 +13,11 @@ import { rejectTransaction, signTransaction } from "popup/ducks/access";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 
-import { getPunycodedDomain } from "helpers/urls";
-
 import { Button } from "popup/basics/Buttons";
 import { SubmitButton } from "popup/basics/Forms";
 
 import { WarningMessage } from "popup/components/WarningMessage";
+import { PunycodedDomain } from "popup/components/PunycodedDomain";
 
 import WarningShieldIcon from "popup/assets/icon-warning-shield.svg";
 
@@ -94,7 +93,6 @@ export const SignTransaction = () => {
     location.search,
   );
 
-  const punycodedDomain = getPunycodedDomain(domain);
   const { _fee, _operations } = transaction;
   const publicKey = useSelector(publicKeySelector);
 
@@ -248,7 +246,10 @@ export const SignTransaction = () => {
           </p>
         </WarningMessage>
       ) : null}
-      <SubheaderEl>{punycodedDomain} is requesting a transaction</SubheaderEl>
+      <PunycodedDomain domain={domain} />
+      <SubheaderEl>
+        This website is requesting a signature to the follwing transaction:
+      </SubheaderEl>
       <ListEl>
         <li>
           <div>


### PR DESCRIPTION
**Summary:**
- `<PunycodedDomain/>` created to display the domain the user is on
- Needs to add favicon

**Screenshots:**
When the punycoded domain is different from the domain url:
<img width="457" alt="invalid-domain" src="https://user-images.githubusercontent.com/3912060/95114144-7c871c80-0711-11eb-9c8b-95321c0d53c9.png">

`<PunycodedDomain/>` on confirm-transaction
<img width="455" alt="punycoded-confirm-transaction" src="https://user-images.githubusercontent.com/3912060/95114145-7db84980-0711-11eb-92d1-791a7adcd0a5.png">

`<PunycodedDomain/>` on share public key for the first time
<img width="456" alt="punycoded-share-publickey-first-time" src="https://user-images.githubusercontent.com/3912060/95114149-7e50e000-0711-11eb-8af6-41bea5eb418e.png">

`<PunycodedDomain/>` on share public key
<img width="453" alt="punycoded-share-publickey" src="https://user-images.githubusercontent.com/3912060/95114155-7ee97680-0711-11eb-8d25-5a023cd8cc9b.png">
