### PR TITLE
clear an API error after failing to recover from mnemonic phrase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,12 @@ module.exports = {
         "import/no-extraneous-dependencies": [0, { devDependencies: false }],
       },
     },
+    {
+      files: ["*/**/ducks/*.ts"],
+      rules: {
+        "no-param-reassign": "off",
+      },
+    },
   ],
   rules: {
     "no-console": 0,

--- a/extension/src/popup/ducks/authServices.ts
+++ b/extension/src/popup/ducks/authServices.ts
@@ -177,7 +177,11 @@ const initialState: InitialState = {
 const authSlice = createSlice({
   name: "auth",
   initialState,
-  reducers: {},
+  reducers: {
+    clearApiError(state) {
+      state.error = "";
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(createAccount.fulfilled, (state, action) => {
       const { publicKey } = action.payload || { publicKey: "" };
@@ -307,5 +311,7 @@ export const publicKeySelector = createSelector(
   authSelector,
   (auth: InitialState) => auth.publicKey,
 );
+
+export const { clearApiError } = authSlice.actions;
 
 export { reducer };

--- a/extension/src/popup/views/RecoverAccount.tsx
+++ b/extension/src/popup/views/RecoverAccount.tsx
@@ -16,6 +16,7 @@ import {
   mnemonicPhrase as mnemonicPhraseValidator,
 } from "popup/helpers/validators";
 import {
+  clearApiError,
   authErrorSelector,
   publicKeySelector,
   recoverAccount,
@@ -94,13 +95,21 @@ export const RecoverAccount = () => {
     }
   }, [publicKey]);
 
+  const clearMnemonicPhraseError = (e: React.ChangeEvent<any>) => {
+    // TODO: This pattern could be reused if we run into more instances of needing to clear an API error
+
+    if (authError && e.target.value === "") {
+      dispatch(clearApiError());
+    }
+  };
+
   return (
     <Formik
       initialValues={initialValues}
       onSubmit={handleSubmit}
       validationSchema={RecoverAccountSchema}
     >
-      {({ dirty, isSubmitting, isValid }) => (
+      {({ dirty, handleChange, isSubmitting, isValid }) => (
         <FullHeightFormEl>
           <Onboarding
             header="Recover wallet from backup phrase"
@@ -113,6 +122,10 @@ export const RecoverAccount = () => {
                 <TextField
                   component="textarea"
                   name="mnemonicPhrase"
+                  onChange={(e: React.ChangeEvent) => {
+                    clearMnemonicPhraseError(e);
+                    handleChange(e);
+                  }}
                   placeholder="Enter your 12 word phrase to restore your wallet"
                 />
                 <Error name="mnemonicPhrase" />


### PR DESCRIPTION
I explored a few different ways to make this scale a bit better, but it would require a fair amount of refactoring. Since we only need to do this in one place, I'll hold off for now and take the easy way out :D